### PR TITLE
refactor: remove need for addresses pre-generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Given a master public key (xpub, Ltub, *etc.*), get the balances of its derived 
 * Search if a given address has been derived from a given master public key
 * Supports legacy, SegWit, and Native Segwit
 
+## Prerequisites
+
+- Node.js, and/or
+- Docker
+
 ## Install
 
 `$ npm i`

--- a/actions/address.js
+++ b/actions/address.js
@@ -75,6 +75,35 @@ class Address {
   }
 }
 
+// addresses belonging to the same xpub
+class OwnAddresses {
+  constructor(type) {
+    this.type = type;
+    this.internal = [];
+    this.external = [];
+  }
+
+  addAddress(address) {
+    if (address.getDerivation().account === 1) {
+      // here, it is assumed that addresses belonging
+      // to account 1 are internal addresses 
+      // (that is: change addresses)
+      this.internal.push(address.toString());
+    }
+    else {
+      this.external.push(address.toString());
+    }
+  }
+
+  getInternalAddresses() {
+    return this.internal;
+  }
+
+  getExternalAddresses() {
+    return this.external;
+  }
+}
+
 // derive legacy address at account and index positions
 function getLegacyAddress(xpub, account, index) {
   const { address } = bjs.payments.p2pkh({
@@ -163,4 +192,4 @@ function getAddressType(address) {
     }
   }
   
-  module.exports = { Address, getAddressType, getAddress }
+  module.exports = { Address, OwnAddresses, getAddressType, getAddress }

--- a/settings.js
+++ b/settings.js
@@ -16,10 +16,6 @@ const LITECOIN_API = 'https://sochain.com/api/v2/address/LTC/';
 // (that is: range of indices not used for derivation)
 const MAX_EXPLORATION = 20;
 
-// number of addresses to pre-generate (used for transactions analysis)
-const ADDRESSES_PREGENERATION = 2000;
-
-
 // XPUB <> ADDRESS COMPARISON
 // --------------------------
 
@@ -67,7 +63,6 @@ const AddressType = {
   LEGACY: "Legacy",
   NATIVE: "Native SegWit",
   SEGWIT: "SegWit",
-  LEGACY_OR_SEGWIT: "Legacy/SegWit",
   ALL: "All"
 };
 
@@ -79,7 +74,6 @@ module.exports = {
   LITECOIN_API,
   MAX_EXPLORATION, 
   VERBOSE, 
-  ADDRESSES_PREGENERATION,
   BITCOIN_NETWORK,
   LITECOIN_NETWORK,
   DERIVATION_SCOPE


### PR DESCRIPTION
Simplify the implementation, notably by removing the need for a pre-generation of addresses at the start of the scan.