### PR TITLE
Detect funds sent from non-sibling to change address

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Run: `$ docker run xpubscan <xpub> [optional: <args>]`
 ### Check Balance
 When an analysis is performed, 3 elements are displayed in the following order:
 * The analysis of each derived active address (type, path, address, current balance, total in `←`, total out `→`)
-* The transactions ordered by date (date, block number, address, in `←` | out `→` | sent to self `⮂` | sent to sibling `↺`)
+* The transactions ordered by date (date, block number, address, in `←` | out `→` | sent to self `⮂` | sent to sibling `↺` | received as change from non-sibling `c`)
 * A summary: total number of transactions and total balance by address type
 
 ### Xpub and Address Comparison

--- a/src/actions/processTransactions.ts
+++ b/src/actions/processTransactions.ts
@@ -60,7 +60,7 @@ function preprocessTransactions(address: Address) {
 function processFundedTransactions(address: Address, ownAddresses: OwnAddresses) {
 
     const transactions = address.getTransactions();
-    const allOwnAddresses = ownAddresses.getAllAddress();
+    const allOwnAddresses = ownAddresses.getAllAddresses();
     const accountNumber = address.getDerivation().account;
     
     for (const tx of transactions) {

--- a/src/actions/processTransactions.ts
+++ b/src/actions/processTransactions.ts
@@ -35,7 +35,7 @@ function getStats(address: Address) {
 
 function getTransactions(address: Address, ownAddresses: OwnAddresses) {
     preprocessTransactions(address);
-    processFundedTransactions(address);
+    processFundedTransactions(address, ownAddresses);
     processSentTransactions(address, ownAddresses);
 }
 
@@ -57,24 +57,31 @@ function preprocessTransactions(address: Address) {
 }
 
 // process amounts received
-function processFundedTransactions(address: Address) {
-    // if change address: no funded transactions
-    if (address.getDerivation().account === 1) {
-        return;
-    }
-    
+function processFundedTransactions(address: Address, ownAddresses: OwnAddresses) {
+
     const transactions = address.getTransactions();
+    const allOwnAddresses = ownAddresses.getAllAddress();
     
-    transactions.forEach(tx => {
+    for (const tx of transactions) {
         if (typeof(tx.ins) !== 'undefined' && tx.ins.length > 0) {
+
+            // if account is internal, return if sender is a sibling
+            if (address.getDerivation().account === 1) {
+                for (let txin of tx.ins) {
+                    if (allOwnAddresses.includes(txin.address)) {
+                        return;
+                    }
+                }
+            }
+                
             const op = new Operation(tx.date, tx.ins[0].amount);
             op.setTxid(tx.txid);
             op.setBlockNumber(tx.blockHeight);
-            op.setType(OperationType.In)
-
+            op.setType(address.getDerivation().account !== 1 ? OperationType.In : OperationType.InChange)
+    
             address.addFundedOperation(op);
         }
-    })
+    }
         
     if (VERBOSE) {
         console.log('FUNDED\t', address.getFundedOperations());

--- a/src/display.ts
+++ b/src/display.ts
@@ -96,7 +96,7 @@ function displayOperations(sortedOperations: Operation[]) {
   }
   
   const header =
-  '\ndate\t\t\tblock\t\taddress\t\t\t\t\t\treceived (←) or sent (→) to self (⮂) or sibling (↺)';
+  '\ndate\t\t\tblock\t\taddress\t\t\t\t\t\treceived (←) [as change from non-sibling (c)] | sent (→) to self (⮂) or sibling (↺)';
   console.log(chalk.grey(header));
   
   sortedOperations.forEach(op => {    
@@ -112,13 +112,18 @@ function displayOperations(sortedOperations: Operation[]) {
       .concat('\t')
       
   
-    if (op.type === OperationType.In) {
+    if (op.type === OperationType.In || op.type === OperationType.InChange) {
       // ... +{amount} ←
       status = 
         status
         .concat('+')
         .concat(amount)
         .concat(' ←');
+
+      if (op.type === OperationType.InChange) {
+        status =
+          status.concat(' c');
+      }
     }
     else {
       // ... -{amount} →|⮂|↺

--- a/src/models/operation.ts
+++ b/src/models/operation.ts
@@ -4,6 +4,7 @@
 
 export enum OperationType {
     In,
+    InChange, // change address having received funds from a non-sibling address
     Out,
     Out_Self,
     Out_Sibling

--- a/src/models/ownAddresses.ts
+++ b/src/models/ownAddresses.ts
@@ -31,7 +31,7 @@ class OwnAddresses {
       return this.external;
     }
 
-    getAllAddress() {
+    getAllAddresses() {
       return this.internal.concat(this.external);
     }
 }

--- a/src/models/ownAddresses.ts
+++ b/src/models/ownAddresses.ts
@@ -30,6 +30,10 @@ class OwnAddresses {
     getExternalAddresses() {
       return this.external;
     }
+
+    getAllAddress() {
+      return this.internal.concat(this.external);
+    }
 }
 
 export { OwnAddresses }


### PR DESCRIPTION
Edge case: it may happen that non-sibling addresses send funds to change addresses. In other words: a change address can receive funds from an address not belonging to the same master public key. This modification takes such a situation into account.

Non-sibling to change address operations are identified with a `← c` in the operations history.