### PR TITLE
feat(external explorers): allow using different explorers

### DIFF
--- a/src/scan.ts
+++ b/src/scan.ts
@@ -12,7 +12,7 @@ import { configuration } from "./settings";
 import { importOperations, checkImportedOperations } from "./actions/importOperations";
 import { save } from "./actions/saveAnalysis"
 
-const VERSION = '0.0.4'
+const VERSION = '0.0.5'
 
 const args = yargs
   .option('account', {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -73,8 +73,10 @@ export enum AddressType {
 
 // HTML REPORT
 // -----------
-const EXTERNAL_EXPLORER_URL = 'https://blockchair.com/{coin}/{type}/{item}'
-
+const EXTERNAL_EXPLORERS_URLS = {
+  general: 'https://live.blockcypher.com/{coin}/{type}/{item}',
+  bch: 'https://blockchair.com/{coin}/{type}/{item}'
+}
 
 Object.freeze(AddressType);
 
@@ -96,5 +98,5 @@ export {
   VERBOSE,
   NETWORKS,
   DERIVATION_SCOPE,
-  EXTERNAL_EXPLORER_URL
+  EXTERNAL_EXPLORERS_URLS
 }


### PR DESCRIPTION
HTML reports: use different explorers depending on the coin that had been analyzed: _blockcypher.com_ for Bitcoin and Litecoin, and _blockchair.com_ for Bitcoin Cash.