### PR TITLE
Refactoring 1 — args validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,34 @@ Example:
 Example: 
 `$ node build/scan.js xpub6C...44dXs7p`
 
-### Compare With Transactions Imported From a File
+### Compare Imported Data With Actual Data
 
-`$ node build/scan.js <xpub> --import <file path>`
+**Balance `--balance <balance>`**
+
+`$ node build/scan.js <xpub> --balance <balance (in satoshis or similar base unit)>`
+
+**Addresses `--addresses <filepath>`**
+
+*(Not implemented yet)*
+
+`$ node build/scan.js <xpub> --addresses <file path>`
+
+**UTXOs `--utxos <filepath>`**
+
+*(Not implemented yet)*
+
+`$ node build/scan.js <xpub> --utxos <file path>`
+
+**Operations `--operations <filepath>`**
+
+`$ node build/scan.js <xpub> --operations <file path>`
 
 Example:
-`$ node build/scan.js xpub6C...44dXs7p --import /Users/Test/Downloads/export.csv`
+`$ node build/scan.js xpub6C...44dXs7p --operations /Users/Test/Downloads/export.csv`
+
+**General Example**
+
+`$ node build/scan.js xpub6C...44dXs7p --operations /Users/Test/Downloads/export.csv --balance 12345 --diff` displays at the end of the analysis the results of the comparison between the `12345` satoshis balance and the actual one, as well as the potential mismatches between the imported operations and the actual ones.
 
 ### Generate JSON and HTML Reports (Scan Only)
 
@@ -68,12 +90,9 @@ The files are saved as `<xpub>.json` and `<xpub>.html`.
 
 Note: `--save stdout` can be used to display the JSON instead of saving the files. Furthermore, the `--quiet` option does not display the analysis progress while the `--silent` option does not display the progress _nor the results_.
 
-### Comparisons-Related Options
+### Comparisons-Related Option
 
 - `--diff` displays the mismatches (if any) between the imported and actual operations.
-- `--balance <balance (in satoshis or similar base unit)>` compares the provided balance with the actual one.
-
-Example: `$ node build/scan.js xpub6C...44dXs7p --import /Users/Test/Downloads/export.csv --balance 12345 --diff` displays at the end of the analysis the results of the comparison between the `12345` satoshis balance and the actual one, as well as the potential mismatches between the imported operations and the actual ones.
 
 ## Usage 2. Check Address Against Xpub
 

--- a/src/actions/checkAddress.ts
+++ b/src/actions/checkAddress.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 
 import { getAddressType, getAddress } from "./deriveAddresses";
-import { DERIVATION_SCOPE } from "../settings";
+import { DERIVATION_SCOPE } from "../configuration/settings";
 
 interface Result {
     partial?: string;

--- a/src/actions/checkBalance.ts
+++ b/src/actions/checkBalance.ts
@@ -4,7 +4,8 @@ import * as display from "../display";
 
 import { Address } from "../models/address";
 import { OwnAddresses } from "../models/ownAddresses";
-import { configuration, AddressType, GAP_LIMIT } from "../settings";
+import { configuration, GAP_LIMIT } from "../configuration/settings";
+import { AddressType } from "../configuration/currencies";
 import { getStats, getTransactions } from "./processTransactions";
 
 // @ts-ignore

--- a/src/actions/deriveAddresses.ts
+++ b/src/actions/deriveAddresses.ts
@@ -5,7 +5,8 @@ import * as bip32 from "bip32";
 import * as bch from "bitcoincashjs";
 import bchaddr from "bchaddrjs";
 
-import { AddressType, configuration } from "../settings";
+import { AddressType } from "../configuration/currencies";
+import { configuration } from "../configuration/settings";
 
 // derive legacy address at account and index positions
 function getLegacyAddress(xpub: string, account: number, index: number) : string {

--- a/src/actions/importOperations.ts
+++ b/src/actions/importOperations.ts
@@ -6,7 +6,7 @@ import sb from "satoshi-bitcoin";
 
 import { Operation } from "../models/operation";
 import { Comparison, ComparisonStatus } from "../models/comparison";
-import { configuration } from "../settings";
+import { configuration } from "../configuration/settings";
 
 interface Txid {
     date: string;

--- a/src/actions/processTransactions.ts
+++ b/src/actions/processTransactions.ts
@@ -1,4 +1,4 @@
-import { VERBOSE, configuration, NETWORKS } from "../settings";
+import { VERBOSE, configuration } from "../configuration/settings";
 import { Address } from "../models/address";
 import { OwnAddresses } from "../models/ownAddresses";
 import { Operation } from "../models/operation";
@@ -219,11 +219,6 @@ function getSortedUTXOS(...addresses: any) : Address[] {
     });
 
     return utxos;
-}
-
-// eslint-disable-next-line no-unused-vars
-function showTransactions(address: Address) {
-    console.dir(address.getTransactions(), { depth: null });
 }
 
 export { getStats, getTransactions, getSortedOperations, getSortedUTXOS };

--- a/src/actions/saveAnalysis.ts
+++ b/src/actions/saveAnalysis.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import minifier from "html-minifier";
 
-import { configuration, GAP_LIMIT, EXTERNAL_EXPLORERS_URLS } from "../settings";
+import { configuration, GAP_LIMIT, EXTERNAL_EXPLORERS_URLS } from "../configuration/settings";
 import { reportTemplate } from "../templates/report.html";
 import { toUnprefixedCashAddress } from "../helpers";
 import { Address } from "../models/address";
@@ -163,7 +163,7 @@ function makeUTXOSTable(object: any) {
         return "";
     }
 
-    let UTXOSTable = `
+    const UTXOSTable = `
     <li class="tab">
     <input type="radio" name="tabs" id="tab3" />
     <label for="tab3">UTXOS</label>

--- a/src/api/customProvider.ts
+++ b/src/api/customProvider.ts
@@ -1,7 +1,7 @@
 import dateFormat from "dateformat";
 
 import * as helpers from "../helpers";
-import { configuration } from "../settings";
+import { configuration } from "../configuration/settings";
 import { Address } from "../models/address";
 import { Transaction } from "../models/transaction";
 import { Operation } from "../models/operation";

--- a/src/api/defaultProvider.ts
+++ b/src/api/defaultProvider.ts
@@ -1,7 +1,7 @@
 import dateFormat from "dateformat";
 
-import { getJSON, toUnprefixedCashAddress } from "../helpers";
-import { configuration, NETWORKS } from "../settings";
+import { getJSON } from "../helpers";
+import { configuration } from "../configuration/settings";
 import { Address } from "../models/address";
 import { Transaction } from "../models/transaction";
 import { Operation } from "../models/operation";

--- a/src/configuration/currencies.ts
+++ b/src/configuration/currencies.ts
@@ -1,0 +1,57 @@
+// @ts-ignore
+import coininfo from "coininfo";
+
+export enum AddressType {
+    LEGACY = "Legacy",
+    NATIVE = "Native SegWit",
+    SEGWIT = "SegWit",
+    BCH    = "Bitcoin Cash"
+}
+Object.freeze(AddressType);
+
+// TODO: complete migratation from settings to currencies 
+export const currencies = {
+    btc_mainnet: {
+        name: "Bitcoin Mainnet",
+        symbol: "BTC",
+        network: coininfo.bitcoin.main.toBitcoinJS(),
+        types: [ AddressType.LEGACY, AddressType.SEGWIT, AddressType.NATIVE ],
+        precision: 100000000
+    },
+    btc_tesnet: {
+        name: "Bitcoin Testnet",
+        symbol: "BTC",
+        network: coininfo.bitcoin.test.toBitcoinJS(),
+        types: [ AddressType.LEGACY, AddressType.SEGWIT, AddressType.NATIVE ],
+        precision: 100000000
+    },
+    bch_mainnet: {
+        name: "Bitcoin Cash Mainnet",
+        symbol: "BCH",
+        network: coininfo.bitcoincash.main.toBitcoinJS(),
+        types: [ AddressType.BCH ],
+        precision: 100000000
+    },
+    bch_tesnet: {
+        name: "Bitcoin Cash Testnet",
+        symbol: "BCH",
+        network: coininfo.bitcoincash.test.toBitcoinJS(),
+        types: [ AddressType.BCH ],
+        precision: 100000000
+    },
+    ltc_mainnet: {
+        name: "Litecoin Mainnet",
+        symbol: "LTC",
+        network: coininfo.litecoin.main.toBitcoinJS(),
+        types: [ AddressType.LEGACY, AddressType.SEGWIT, AddressType.NATIVE ],
+        precision: 100000000
+        
+    },
+    ltc_tesnet: {
+        name: "Litecoin Testnet",
+        symbol: "LTC",
+        network: coininfo.litecoin.test.toBitcoinJS(),
+        types: [ AddressType.LEGACY, AddressType.SEGWIT, AddressType.NATIVE ],
+        precision: 100000000
+    },
+};

--- a/src/configuration/settings.ts
+++ b/src/configuration/settings.ts
@@ -55,30 +55,12 @@ const DERIVATION_SCOPE = {
   }
 };
 
-
-// DERIVATION PARAMETERS
-// ---------------------
-const NETWORKS = {
-  bitcoin_mainnet: coininfo.bitcoin.main.toBitcoinJS(),
-  bitcoin_cash_mainnet: coininfo.bitcoincash.main.toBitcoinJS(),
-  litecoin_mainnet: coininfo.litecoin.main.toBitcoinJS()
-};
-
-export enum AddressType {
-  LEGACY = "Legacy",
-  NATIVE = "Native SegWit",
-  SEGWIT = "SegWit",
-  BCH    = "Bitcoin Cash"
-}
-
 // HTML REPORT
 // -----------
 const EXTERNAL_EXPLORERS_URLS = {
   general: "https://live.blockcypher.com/{coin}/{type}/{item}",
   bch: "https://blockchair.com/{coin}/{type}/{item}"
 };
-
-Object.freeze(AddressType);
 
 dotenv.config();
 export const configuration = {
@@ -97,7 +79,6 @@ export {
   DEFAULT_API_URLS,
   GAP_LIMIT,
   VERBOSE,
-  NETWORKS,
   DERIVATION_SCOPE,
   EXTERNAL_EXPLORERS_URLS
 };

--- a/src/display.ts
+++ b/src/display.ts
@@ -3,7 +3,7 @@ import chalk from "chalk";
 
 import { Address } from "./models/address";
 import { Operation } from "./models/operation";
-import { configuration } from "./settings";
+import { configuration } from "./configuration/settings";
 
 function convertUnits(amount: number) {
   // Currently, this function does not convert the amounts

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -4,10 +4,8 @@ import * as bip32 from "bip32";
 import chalk from "chalk";
 import bchaddr from "bchaddrjs";
 
-import { 
-  NETWORKS,
-  configuration 
-} from "./settings";
+import { configuration } from "./configuration/settings";
+import { currencies } from "./configuration/currencies";
 
 // TODO: properly rework this function
 function getJSON(url: string, APIKey?: string) {
@@ -39,12 +37,12 @@ function setNetwork(xpub: string, currency?: string) {
     const prefix = xpub.substring(0, 4);
   
     if (prefix === "xpub") {
-      configuration.network = NETWORKS.bitcoin_mainnet;
+      configuration.network = currencies.btc_mainnet.network;
       configuration.currency = "Bitcoin";
       configuration.symbol = "BTC";
     }
     else if (prefix === "Ltub") {
-      configuration.network = NETWORKS.litecoin_mainnet;
+      configuration.network = currencies.ltc_mainnet.network;
       configuration.currency = "Litecoin";
       configuration.symbol = "LTC";
     }
@@ -56,7 +54,7 @@ function setNetwork(xpub: string, currency?: string) {
     currency = currency.toLowerCase();
     // Bitcoin Cash
     if (currency.includes("cash") || currency === "BCH") {
-      configuration.network = NETWORKS.bitcoin_cash_mainnet;
+      configuration.network = currencies.bch_mainnet.network;
       configuration.currency = "Bitcoin Cash";
       configuration.symbol = "BCH";
       return;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -33,7 +33,7 @@ function getJSON(url: string, APIKey?: string) {
 }
 
 function setNetwork(xpub: string, currency?: string) {
-  if (typeof(currency) === "undefined") {
+  if (typeof(currency) === "undefined" || currency === "BTC" || currency === "LTC") {
     const prefix = xpub.substring(0, 4);
   
     if (prefix === "xpub") {
@@ -51,7 +51,7 @@ function setNetwork(xpub: string, currency?: string) {
     }
   }
   else {
-    currency = currency.toLowerCase();
+
     // Bitcoin Cash
     if (currency.includes("cash") || currency === "BCH") {
       configuration.network = currencies.bch_mainnet.network;

--- a/src/input/args.ts
+++ b/src/input/args.ts
@@ -50,6 +50,11 @@ export const getArgs = (): any => {
             type: "boolean"
         })
         // imported data
+        .option("import", {
+            description: "[DEPRECATED] Import operations (file) for comparison",
+            demand: false,
+            type: "string"
+        })
         .option("addresses", {
             description: "Import addresses (file) for comparison",
             demand: false,

--- a/src/input/args.ts
+++ b/src/input/args.ts
@@ -1,0 +1,84 @@
+import yargs from "yargs";
+import { checkArgs } from "./check";
+
+/**
+ * Returns the valid args entered by the user
+ * @returns any 
+ *          The validated args
+ */
+export const getArgs = (): any => {
+    const args = yargs
+        // primary options
+        .option("currency", {
+            description: "currency",
+            demand: false,
+            type: "string",
+        })
+        .option("account", {
+            alias: "a",
+            description: "Account number",
+            demand: false,
+            type: "number"
+        })
+        .option("index", {
+            alias: "i",
+            description: "Index number",
+            demand: false,
+            type: "number"
+        })
+        .option("address", {
+            description: "Address",
+            demand: false,
+            type: "string"
+        })
+        // stdout options
+        .option("silent", {
+            description: "Do not display anything (except for the filepath of the saved reports)",
+            demand: false,
+            type: "boolean",
+            default: false
+        })
+        .option("quiet", {
+            description: "Do not display analysis progress",
+            demand: false,
+            type: "boolean",
+            default: false
+        })
+        .option("diff", {
+            description: "Show diffs",
+            demand: false,
+            type: "boolean"
+        })
+        // imported data
+        .option("addresses", {
+            description: "Import addresses (file) for comparison",
+            demand: false,
+            type: "string"
+        })
+        .option("balance", {
+            description: "Import balance for comparison (has to be in satoshis or similar base unit) for comparison",
+            demand: false,
+            type: "number"
+        })
+        .option("utxos", {
+            description: "Import UTXOs (file) for comparison",
+            demand: false,
+            type: "string"
+        })
+        .option("operations", {
+            description: "Import operations history (file) for comparison",
+            demand: false,
+            type: "string"
+        })
+        // save
+        .option("save", {
+            description: "Save analysis",
+            demand: false,
+            type: "string",
+        })
+        .argv;
+
+    checkArgs(args);
+    
+    return args;
+};

--- a/src/input/check.ts
+++ b/src/input/check.ts
@@ -1,4 +1,7 @@
 import fs from "fs";
+import chalk from "chalk";
+import { currencies } from "../configuration/currencies";
+
 /**
  * Ensure that args are valid
  * @param  {any} args
@@ -11,6 +14,7 @@ export const checkArgs = (args: any): void => {
     const address = args.address;
     const balance = args.balance;
     const save = args.save;
+    const currency = args.currency;
 
     // xpub: set, non-empty
     if (typeof(xpub) === "undefined" || xpub === "") {
@@ -22,13 +26,46 @@ export const checkArgs = (args: any): void => {
         throw new Error("Address should not be empty");
     }
 
-    // imported balance: integer
+    // imported balance: integer (i.e., base unit)
     if (typeof(balance) !== "undefined") {
         if (balance % 1 !== 0) {
             throw new Error("Balance is not an integer: " + balance);
         }
     }
-    
+
+    // currency: exists
+    if (typeof(currency) !== "undefined") {
+        args.currency = args.currency.toUpperCase();
+
+        const currencyProperties = 
+            Object.entries(currencies).filter(c => c[1].symbol.toUpperCase() === args.currency.toUpperCase());
+
+        if (currencyProperties.length === 0) {
+            throw new Error("Currency '" + currency + "' has not been implemented yet");
+        }
+    }
+
+    // warnings: not implemented yet
+    if (typeof(args.addresses) !== "undefined") {
+        console.log(
+            chalk.bgYellowBright.black(" Warning: `--addresses` option has not been implemented yet. Skipped. ")
+            );
+    }
+
+    if (typeof(args.utxos) !== "undefined") {
+        console.log(
+            chalk.bgYellowBright.black(" Warning: `--utxos` option has not been implemented yet. Skipped. ")
+            );
+    }
+
+    // deprecated: --import
+    if (typeof(args.import) !== "undefined") {
+        console.log(
+            chalk.bgYellowBright.black(" Warning: `--import` option is deprecated. Please use `--operations` instead. ")
+            );
+        args.operations = args.import;
+    }
+
     // imported files: non-empty, exist
     const importedFiles = [args.addresses, args.utxos, args.operations];
     for (const importedFile of importedFiles) {

--- a/src/input/check.ts
+++ b/src/input/check.ts
@@ -1,0 +1,59 @@
+import fs from "fs";
+/**
+ * Ensure that args are valid
+ * @param  {any} args
+ * @returns void
+ */
+export const checkArgs = (args: any): void => {
+    args.xpub = args._[0];
+
+    const xpub = args.xpub;
+    const address = args.address;
+    const balance = args.balance;
+    const save = args.save;
+
+    // xpub: set, non-empty
+    if (typeof(xpub) === "undefined" || xpub === "") {
+        throw new Error("Xpub is required");
+    }
+
+    // address: non-empty
+    if (typeof(address) !== "undefined" && address === "") {
+        throw new Error("Address should not be empty");
+    }
+
+    // imported balance: integer
+    if (typeof(balance) !== "undefined") {
+        if (balance % 1 !== 0) {
+            throw new Error("Balance is not an integer: " + balance);
+        }
+    }
+    
+    // imported files: non-empty, exist
+    const importedFiles = [args.addresses, args.utxos, args.operations];
+    for (const importedFile of importedFiles) {
+        if (typeof(importedFile) !== "undefined") {
+            if (importedFile === "" || !fs.existsSync(importedFile)) {
+                throw new Error("Imported file " + importedFile + " does not exist");
+            }
+        }
+    }
+
+    // save dirpath: exists, is a directory, writtable
+    if (typeof(save) !== "undefined") {
+        try {
+            if (!fs.statSync(save).isDirectory()) {
+                throw new Error("Save path " + save + " is not a directory");
+            }
+        }
+        catch {
+            throw new Error("Save path " + save + " does not exist");
+        }
+        
+        fs.access(save, fs.constants.W_OK, function(err) {
+            if (err) {
+                throw new Error("Save directory " + save + " is not writtable");
+            }
+        });
+    }
+};

--- a/src/input/check.ts
+++ b/src/input/check.ts
@@ -76,7 +76,7 @@ export const checkArgs = (args: any): void => {
         }
     }
 
-    // save dirpath: exists, is a directory, writtable
+    // save dirpath: exists, is a directory, writable
     if (typeof(save) !== "undefined") {
         try {
             if (!fs.statSync(save).isDirectory()) {
@@ -89,7 +89,7 @@ export const checkArgs = (args: any): void => {
         
         fs.access(save, fs.constants.W_OK, function(err) {
             if (err) {
-                throw new Error("Save directory " + save + " is not writtable");
+                throw new Error("Save directory " + save + " is not writable");
             }
         });
     }

--- a/src/models/address.ts
+++ b/src/models/address.ts
@@ -1,4 +1,5 @@
-import { AddressType, configuration, NETWORKS } from "../settings";
+import { configuration } from "../configuration/settings";
+import { AddressType } from "../configuration/currencies";
 import { Transaction } from "./transaction";
 import { Operation } from "./operation";
 import { Stats } from "./stats";

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 import chalk from "chalk";
-import yargs from "yargs";
 
 import * as check_balances from "./actions/checkBalance";
 import * as compare from "./actions/checkAddress";
@@ -11,64 +10,11 @@ import { init } from "./helpers";
 import { importOperations, checkImportedOperations, showDiff } from "./actions/importOperations";
 import { save } from "./actions/saveAnalysis";
 import { Address } from "./models/address";
+import { getArgs } from "./input/args";
 
-const VERSION = "0.0.7";
+const VERSION = "0.0.8";
 
-const args = yargs
-  .option("account", {
-      alias: "a",
-      description: "Account number",
-      demand: false,
-      type: "number"
-  })
-  .option("index", {
-      alias: "i",
-      description: "Index number",
-      demand: false,
-      type: "number"
-  })
-  .option("address", {
-      description: "Address",
-      demand: false,
-      type: "string"
-  })
-  .option("import", {
-    description: "Import transactions",
-    demand: false,
-    type: "string"
-  })
-  .option("balance", {
-    description: "Import balance for comparison (as to be in satoshis or similar base unit)",
-    demand: false,
-    type: "number"
-  })
-  .option("diff", {
-    description: "Show diffs",
-    demand: false,
-    type: "boolean"
-  })
-  .option("save", {
-    description: "Save analysis",
-    demand: false,
-    type: "string",
-  })
-  .option("silent", {
-    description: "Do not display anything (except for the filepath of the saved reports)",
-    demand: false,
-    type: "boolean",
-    default: false
-  })
-  .option("quiet", {
-    description: "Do not display analysis progress",
-    demand: false,
-    type: "boolean",
-    default: false
-  })
-  .option("currency", {
-    description: "currency",
-    demand: false,
-    type: "string",
-  }).argv;
+const args = getArgs();
 
 const account = args.account;
 const index = args.index;

--- a/src/templates/report.html.ts
+++ b/src/templates/report.html.ts
@@ -187,14 +187,14 @@ export const reportTemplate = `
         box-shadow: inset -1px -1px 0 #fff;
       }
       
-      .tabs{
-          width: 98%;
-          display: block;
-          position: relative;
-      }
-      
       /* tabs | from https://codepen.io/dhs/pen/diasg */
 
+      .tabs{
+          display: flex;
+          position: relative;
+          justify-content: center;
+      }
+      
       .tabs .tab{
           float: left;
           display: block;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,19 +26,19 @@
 
     /* Strict Type-Checking Options */
     "strict": true,                           /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,              /* Enable strict null checks. */
-    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
-    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    "strictNullChecks": true,              /* Enable strict null checks. */
+    "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
     "strictPropertyInitialization": false,  /* Enable strict checking of property initialization in classes. */
-    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
-    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+    "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 
     /* Additional Checks */
-    // "noUnusedLocals": true,                /* Report errors on unused locals. */
-    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
-    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
-    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+    "noUnusedLocals": true,                /* Report errors on unused locals. */
+    "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
     // "noUncheckedIndexedAccess": true,      /* Include 'undefined' in index signature results */
 
     /* Module Resolution Options */


### PR DESCRIPTION
First refactoring:

- **Warning: `--import` is being deprecated.** Rationale: it was originally used to exclusively compare operations. As the comparison feature will soon be expanded, more granularity is needed (see new options, below)
- New options: `--operations` (replaces `--import`), `--utxos` (not implemented yet), and `--addresses` (not implemented yet)
- Args validation to ensure that the options are valid (e.g., ensure that the save directory is writable)
- HTML report menu is now centered (thanks to @meriadec)
- New currencies properties