### PR TITLE
feat(derivation mode): save in individual JSON files

### DIFF
--- a/src/input/check.ts
+++ b/src/input/check.ts
@@ -88,7 +88,7 @@ export const checkArgs = (args: TODO_TypeThis): void => {
   }
 
   // save dirpath: exists, is a directory, writable
-  if (typeof save !== "undefined") {
+  if (typeof save !== "undefined" && save.toLocaleLowerCase() !== "stdout") {
     try {
       if (!fs.statSync(save).isDirectory()) {
         throw new Error("Save path " + save + " is not a directory");

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -100,10 +100,21 @@ async function scan() {
       }
     }
 
+    let mode: string;
+
+    if (typeof args.account !== "undefined" && typeof args.index !== "undefined") {
+      mode = `m/${args.account}/${args.index}`
+    }
+    else {
+      mode = "Full"
+    }
+    // TODO: range mode
+
     const meta = {
       xpub,
       date: now,
       version: VERSION,
+      mode
     };
 
     const data = {

--- a/src/templates/report.html.ts
+++ b/src/templates/report.html.ts
@@ -255,6 +255,7 @@ export const reportTemplate = `
         <li><strong>Analysis date:</strong> {analysis_date}</li>
         <li><strong>Provider:</strong> {provider} ({provider_url})</li>
         <li><strong>Gap limit:</strong> {gap_limit}</li>
+        <li><strong>Scan mode:</strong> {mode}</li>
         <li><strong>Xpub Scan version:</strong> {version}</li>
       </ul>
     </div>


### PR DESCRIPTION
When derivation mode is used with the save option (`-a {account number} -i {index number} --save {directory}`), save each the resulting JSON file with a unique filename containing the account and index numbers. 

Furthermore, specify the scan mode (full v. specific derivation path) in the HTML and JSON reports.