### PR TITLE
Range mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,14 @@ _In the following instructions, the generic `xpub` term is used to designate a m
 Example:
 `$ node lib/scan.js xpub6C...44dXs7p -a 0 -i 10` [addresses at account `0`, index `10`]
 
-### Scan All Active Addresses
+### Range Scan | Scan Addresses Derived From Index A to Index B
+
+`$ node lib/scan.js <xpub> -a <account> --from-index <index A> --to-index <index B>`
+
+Example:
+`$ node lib/scan.js xpub6C...44dXs7p -a 0 --from-index 0 --to-index 100` [addresses at account `0`, from index `0` to index `100`, included]
+
+### Full Scan | Scan All Active Addresses
 
 `$ node lib/scan.js <xpub>`
 

--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ _In the following instructions, the generic `xpub` term is used to designate a m
 Example:
 `$ node lib/scan.js xpub6C...44dXs7p -a 0 -i 10` [addresses at account `0`, index `10`]
 
-### Range Scan | Scan Addresses Derived From Index A to Index B
+### ScanLimits Scan | Scan Addresses Derived From Index A to Index B
 
-`$ node lib/scan.js <xpub> -a <account> --from-index <index A> --to-index <index B>`
+`$ xpub-scan <xpub> -a <account> --from-index <index A> --to-index <index B>`
 
 Example:
-`$ node lib/scan.js xpub6C...44dXs7p -a 0 --from-index 0 --to-index 100` [addresses at account `0`, from index `0` to index `100`, included]
+`$ xpub-scan xpub6C...44dXs7p -a 0 --from-index 0 --to-index 100` [addresses at account `0`, from index `0` to index `100`, included]
 
 ### Full Scan | Scan All Active Addresses
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Example 1:
 Example 2:
 `$ xpub-scan xpub6C...44dXs7p -a 1 --from-index 29` [addresses at account `0`, from index `29` until no active address]
 
+Note: in order to perform the analysis in this context, Xpub Scan needs to pre-derive addresses. By default, it derives 2,000 addresses per account number. If needed, this number of addresses can be adjusted using the `--pre-derivation-size` option (useful with xpub associated with a large number of addresses).
+
 ### Full Scan | Scan All Active Addresses
 
 `$ xpub-scan <xpub>`

--- a/README.md
+++ b/README.md
@@ -79,17 +79,20 @@ _In the following instructions, the generic `xpub` term is used to designate a m
 
 ### Scan for a Specific Account and an Index
 
-`$ xpub-scan <xpub> -a <account> -i <index>`
+`$ xpub-scan <xpub> --account <account> --index <index>`
 
 Example:
 `$ xpub-scan xpub6C...44dXs7p -a 0 -i 10` [addresses at account `0`, index `10`]
 
 ### ScanLimits Scan | Scan Addresses Derived From Index A to Index B
 
-`$ xpub-scan <xpub> -a <account> --from-index <index A> --to-index <index B>`
+`$ xpub-scan <xpub> --account <account> --from-index <index A> [--to-index <index B>]`
 
-Example:
+Example 1:
 `$ xpub-scan xpub6C...44dXs7p -a 0 --from-index 0 --to-index 100` [addresses at account `0`, from index `0` to index `100`, included]
+
+Example 2:
+`$ xpub-scan xpub6C...44dXs7p -a 1 --from-index 29` [addresses at account `0`, from index `29` until no active address]
 
 ### Full Scan | Scan All Active Addresses
 

--- a/src/actions/checkAddress.ts
+++ b/src/actions/checkAddress.ts
@@ -149,16 +149,6 @@ function sanityCheck(xpub: string, provided: string) {
   // check assumptions regarding the provided address
   const derived = getAddress(getAddressType(provided), xpub, 0, 0);
 
-  if (derived.length !== provided.length) {
-    // assumption 1. size of provided === size of derived
-    showError(
-      "Provided address size ≠ derived address size",
-      derived,
-      provided,
-    );
-    return false;
-  }
-
   if (derived.toUpperCase()[0] !== provided.toUpperCase()[0]) {
     // assumption 2. derived and provided share the same prefix
     showError("Prefixes mismatch", derived, provided);

--- a/src/actions/checkBalance.ts
+++ b/src/actions/checkBalance.ts
@@ -37,7 +37,11 @@ async function scanAddresses(
     indexFromSpan = scanLimits.indexFrom;
     indexToSpan = scanLimits.indexTo;
 
-    let maxPreDerivationIndex = 1000;
+    // WARNING: magic number
+    // if the scanned xpub contains more active addresses
+    // for a given account number, the results of the
+    // analysis will be erroneous
+    let maxPreDerivationIndex = 2000;
 
     if (typeof indexToSpan !== "undefined") {
       maxPreDerivationIndex += indexToSpan;

--- a/src/actions/checkBalance.ts
+++ b/src/actions/checkBalance.ts
@@ -36,6 +36,15 @@ async function scanAddresses(
     accountSpan = scanLimits.account;
     indexFromSpan = scanLimits.indexFrom;
     indexToSpan = scanLimits.indexTo;
+
+    // important step: precompute the addresss belonging
+    // to the same xpub in order to perform
+    // transaction analysis further down the flow
+    for (let a = 0; a < 2; a++) {
+      for (let i = 0; i < indexToSpan + 1000; i++) {
+        ownAddresses.addAddress(new Address(addressType, xpub, a, i));
+      }
+    }
   }
 
   // TODO: should we limit ourselves to account 0 and 1?
@@ -56,7 +65,10 @@ async function scanAddresses(
 
     for (let index = 0 /* scan all active indices */; ; ++index) {
       // scan span 2: indices
-      if (indexFromSpan && indexToSpan) {
+      if (
+        typeof indexFromSpan !== "undefined" &&
+        typeof indexToSpan !== "undefined"
+      ) {
         if (index < indexFromSpan) {
           continue;
         }

--- a/src/actions/checkBalance.ts
+++ b/src/actions/checkBalance.ts
@@ -37,11 +37,17 @@ async function scanAddresses(
     indexFromSpan = scanLimits.indexFrom;
     indexToSpan = scanLimits.indexTo;
 
+    let maxPreDerivationIndex = 1000;
+
+    if (typeof indexToSpan !== "undefined") {
+      maxPreDerivationIndex += indexToSpan;
+    }
+
     // important step: precompute the addresss belonging
     // to the same xpub in order to perform
     // transaction analysis further down the flow
     for (let a = 0; a < 2; a++) {
-      for (let i = 0; i < indexToSpan + 1000; i++) {
+      for (let i = 0; i < maxPreDerivationIndex; i++) {
         ownAddresses.addAddress(new Address(addressType, xpub, a, i));
       }
     }
@@ -65,17 +71,12 @@ async function scanAddresses(
 
     for (let index = 0 /* scan all active indices */; ; ++index) {
       // scan span 2: indices
-      if (
-        typeof indexFromSpan !== "undefined" &&
-        typeof indexToSpan !== "undefined"
-      ) {
-        if (index < indexFromSpan) {
-          continue;
-        }
+      if (typeof indexFromSpan !== "undefined" && index < indexFromSpan) {
+        continue;
+      }
 
-        if (index > indexToSpan) {
-          break;
-        }
+      if (typeof indexToSpan !== "undefined" && index > indexToSpan) {
+        break;
       }
 
       const address = new Address(addressType, xpub, account, index);

--- a/src/actions/checkBalance.ts
+++ b/src/actions/checkBalance.ts
@@ -39,7 +39,7 @@ async function scanAddresses(
     indexToSpan = scanLimits.indexTo;
     preDerivationSize = scanLimits.preDerivationSize;
 
-    // important step: precompute the addresss belonging
+    // important step: precompute the addresses belonging
     // to the same xpub in order to perform
     // transaction analysis further down the flow
     for (let a = 0; a < 2; a++) {

--- a/src/actions/checkBalance.ts
+++ b/src/actions/checkBalance.ts
@@ -31,27 +31,19 @@ async function scanAddresses(
   let accountSpan = undefined;
   let indexFromSpan = undefined;
   let indexToSpan = undefined;
+  let preDerivationSize = undefined;
 
   if (scanLimits) {
     accountSpan = scanLimits.account;
     indexFromSpan = scanLimits.indexFrom;
     indexToSpan = scanLimits.indexTo;
-
-    // WARNING: magic number
-    // if the scanned xpub contains more active addresses
-    // for a given account number, the results of the
-    // analysis will be erroneous
-    let maxPreDerivationIndex = 2000;
-
-    if (typeof indexToSpan !== "undefined") {
-      maxPreDerivationIndex += indexToSpan;
-    }
+    preDerivationSize = scanLimits.preDerivationSize;
 
     // important step: precompute the addresss belonging
     // to the same xpub in order to perform
     // transaction analysis further down the flow
     for (let a = 0; a < 2; a++) {
-      for (let i = 0; i < maxPreDerivationIndex; i++) {
+      for (let i = 0; i < preDerivationSize; i++) {
         ownAddresses.addAddress(new Address(addressType, xpub, a, i));
       }
     }

--- a/src/actions/saveAnalysis.ts
+++ b/src/actions/saveAnalysis.ts
@@ -338,10 +338,10 @@ function saveHTML(object: TODO_TypeThis, filepath: string) {
   }
 
   // warning range
-  if (object.meta.mode !== "Full") {
+  if (!object.meta.mode.startsWith("Full")) {
     report = report.replace(
       "{warning_range}",
-      `<div id='warning_range'>The data is based on a partial scan: ${object.meta.mode}</div>`,
+      `<div id='warning_range'>The data is based on a partial scan:<br/> ${object.meta.mode}</div>`,
     );
   } else {
     report = report.replace("{warning_range}", "");
@@ -547,6 +547,11 @@ function save(meta: TODO_TypeThis, data: TODO_TypeThis, directory: string) {
       comparisons.filter((comparison) => comparison.status !== "Match") || [];
   }
 
+  let warningRange;
+  if (!meta.mode.startsWith("Full")) {
+    warningRange = `! The data is based on a partial scan: ${meta.mode} !`;
+  }
+
   const object = {
     meta: {
       by: "xpub scan <https://github.com/LedgerHQ/xpub-scan>",
@@ -559,6 +564,7 @@ function save(meta: TODO_TypeThis, data: TODO_TypeThis, directory: string) {
       gap_limit: GAP_LIMIT,
       unit: "Base unit (i.e., satoshis or equivalent unit)",
       mode: meta.mode,
+      warningRange,
     },
     addresses,
     utxos,
@@ -576,13 +582,6 @@ function save(meta: TODO_TypeThis, data: TODO_TypeThis, directory: string) {
   let filepath = directory;
   if (filepath.toLocaleLowerCase() !== "stdout") {
     filepath += `/${meta.xpub}`;
-
-    if (meta.mode.startsWith("m/")) {
-      // use derivation path as filename postfix: `m/x/y` => `-x-y`
-      // (+TODO: range mode)
-      filepath += meta.mode.replace("m", "").replace(/\//gi, "-");
-    }
-
     saveHTML(object, filepath); // do not save HTML if stdout
   }
 

--- a/src/actions/saveAnalysis.ts
+++ b/src/actions/saveAnalysis.ts
@@ -337,6 +337,16 @@ function saveHTML(object: TODO_TypeThis, filepath: string) {
     report = report.split("{" + key + "}").join(object.meta[key]);
   }
 
+  // warning range
+  if (object.meta.mode !== "Full") {
+    report = report.replace(
+      "{warning_range}",
+      `<div id='warning_range'>The data is based on a partial scan: ${object.meta.mode}</div>`,
+    );
+  } else {
+    report = report.replace("{warning_range}", "");
+  }
+
   // summary
   const summary: string[] = [];
   for (const e of object.summary) {

--- a/src/actions/saveAnalysis.ts
+++ b/src/actions/saveAnalysis.ts
@@ -567,7 +567,7 @@ function save(meta: TODO_TypeThis, data: TODO_TypeThis, directory: string) {
   if (filepath.toLocaleLowerCase() !== "stdout") {
     filepath += `/${meta.xpub}`;
 
-    if (meta.mode !== "Full") {
+    if (meta.mode.startsWith("m/")) {
       // use derivation path as filename postfix: `m/x/y` => `-x-y`
       // (+TODO: range mode)
       filepath += meta.mode.replace("m", "").replace(/\//gi, "-");

--- a/src/actions/saveAnalysis.ts
+++ b/src/actions/saveAnalysis.ts
@@ -333,6 +333,15 @@ function saveHTML(object: TODO_TypeThis, filepath: string) {
   let report = reportTemplate;
 
   // meta
+  if (typeof object.meta.preDerivationSize === "undefined") {
+    report = report.replace("{pre_derivation_size}", "");
+  } else {
+    report = report.replace(
+      "{pre_derivation_size}",
+      `(pre-derivation size: ${object.meta.preDerivationSize})`,
+    );
+  }
+
   for (const key of Object.keys(object.meta)) {
     report = report.split("{" + key + "}").join(object.meta[key]);
   }
@@ -564,6 +573,7 @@ function save(meta: TODO_TypeThis, data: TODO_TypeThis, directory: string) {
       gap_limit: GAP_LIMIT,
       unit: "Base unit (i.e., satoshis or equivalent unit)",
       mode: meta.mode,
+      preDerivationSize: meta.preDerivationSize,
       warningRange,
     },
     addresses,

--- a/src/comparison/compareOperations.ts
+++ b/src/comparison/compareOperations.ts
@@ -1,5 +1,6 @@
 import chalk from "chalk";
 
+import { Address } from "../models/address";
 import { Operation } from "../models/operation";
 import { Comparison, ComparisonStatus } from "../models/comparison";
 import { configuration } from "../configuration/settings";
@@ -199,6 +200,8 @@ const showOperations = (
 const checkImportedOperations = (
   importedOperations: Operation[],
   actualOperations: Operation[],
+  actualAddresses: Address[],
+  fullComparison?: boolean,
 ): Comparison[] => {
   if (!configuration.silent) {
     console.log(
@@ -211,9 +214,17 @@ const checkImportedOperations = (
     );
   }
 
-  // eslint-disable-next-line no-undef
   const allComparingCriteria: ComparingCriterion[] = []; // TODO: convert into a Set as they have to be unique
   const comparisons: Comparison[] = [];
+
+  // filter imported operations if scan is limited
+  if (!fullComparison) {
+    const rangeAddresses = actualAddresses.map((address) => address.toString());
+
+    importedOperations = importedOperations.filter((op) =>
+      op.address.split(",").find((a) => rangeAddresses.includes(a)),
+    );
+  }
 
   importedOperations.forEach((op) => {
     if (!allComparingCriteria.some((t) => t.hash === op.txid)) {

--- a/src/comparison/compareOperations.ts
+++ b/src/comparison/compareOperations.ts
@@ -201,7 +201,7 @@ const checkImportedOperations = (
   importedOperations: Operation[],
   actualOperations: Operation[],
   actualAddresses: Address[],
-  fullComparison?: boolean,
+  partialComparison?: boolean,
 ): Comparison[] => {
   if (!configuration.silent) {
     console.log(
@@ -218,7 +218,7 @@ const checkImportedOperations = (
   const comparisons: Comparison[] = [];
 
   // filter imported operations if scan is limited
-  if (!fullComparison) {
+  if (partialComparison) {
     const rangeAddresses = actualAddresses.map((address) => address.toString());
 
     importedOperations = importedOperations.filter((op) =>

--- a/src/input/args.ts
+++ b/src/input/args.ts
@@ -38,6 +38,11 @@ export const getArgs = (): TODO_TypeThis => {
       demand: false,
       type: "number",
     })
+    .option("pre-derivation-size", {
+      description: "ScanLimits: number of pre-derived addresses per account",
+      demand: false,
+      type: "number",
+    })
     .option("address", {
       description: "Address",
       demand: false,

--- a/src/input/args.ts
+++ b/src/input/args.ts
@@ -29,12 +29,12 @@ export const getArgs = (): TODO_TypeThis => {
       type: "number",
     })
     .option("from-index", {
-      description: "Range: FROM index X",
+      description: "ScanLimits: FROM index X",
       demand: false,
       type: "number",
     })
     .option("to-index", {
-      description: "Range: TO index Y",
+      description: "ScanLimits: TO index Y",
       demand: false,
       type: "number",
     })

--- a/src/input/args.ts
+++ b/src/input/args.ts
@@ -28,6 +28,16 @@ export const getArgs = (): TODO_TypeThis => {
       demand: false,
       type: "number",
     })
+    .option("from-index", {
+      description: "Range: FROM index X",
+      demand: false,
+      type: "number",
+    })
+    .option("to-index", {
+      description: "Range: TO index Y",
+      demand: false,
+      type: "number",
+    })
     .option("address", {
       description: "Address",
       demand: false,

--- a/src/input/check.ts
+++ b/src/input/check.ts
@@ -108,7 +108,7 @@ export const checkArgs = (args: TODO_TypeThis): void => {
     });
   }
 
-  // account/index/range options
+  // account/index/scanLimits options
   if (typeof account !== "undefined") {
     // -a {positive number}
     if (account < 0) {
@@ -123,7 +123,7 @@ export const checkArgs = (args: TODO_TypeThis): void => {
       (typeof fromIndex === "undefined" || typeof toIndex === "undefined")
     ) {
       throw new Error(
-        "Index or range is required when account number option (`-a`) is enabled",
+        "Index or scanLimits is required when account number option (`-a`) is enabled",
       );
     }
 
@@ -138,7 +138,7 @@ export const checkArgs = (args: TODO_TypeThis): void => {
       // -a X --from-index {postive number} --to-index {postive number}
       if (fromIndex < 0 || toIndex < 0) {
         throw new Error(
-          "Range option is required to contain positive (including zero) numbers",
+          "ScanLimits option is required to contain positive (including zero) numbers",
         );
       }
 
@@ -158,8 +158,28 @@ export const checkArgs = (args: TODO_TypeThis): void => {
     // -a X --from-index Y --to-index Z
     if (typeof fromIndex !== "undefined" || typeof toIndex !== "undefined") {
       throw new Error(
-        "Account number is required when range index option (`--from-index`, `--to-index`) is enabled",
+        "Account number is required when scanLimits index option (`--from-index`, `--to-index`) is enabled",
       );
+    }
+  }
+
+  // if needed, create scanLimits
+  if (typeof account !== "undefined") {
+    if (typeof index !== "undefined") {
+      args.scanLimits = {
+        account,
+        indexFrom: index,
+        indexTo: index,
+      };
+    } else if (
+      typeof fromIndex !== "undefined" &&
+      typeof toIndex !== "undefined"
+    ) {
+      args.scanLimits = {
+        account,
+        indexFrom: fromIndex,
+        indexTo: toIndex,
+      };
     }
   }
 };

--- a/src/input/check.ts
+++ b/src/input/check.ts
@@ -17,6 +17,10 @@ export const checkArgs = (args: TODO_TypeThis): void => {
   const balance = args.balance;
   const save = args.save;
   const currency = args.currency;
+  const account = args.account;
+  const index = args.index;
+  const fromIndex = args.fromIndex;
+  const toIndex = args.toIndex;
 
   // xpub: set, non-empty
   if (typeof xpub === "undefined" || xpub === "") {
@@ -102,5 +106,46 @@ export const checkArgs = (args: TODO_TypeThis): void => {
         throw new Error("Save directory " + save + " is not writable");
       }
     });
+  }
+
+  // account/index/range options
+  if (typeof account !== "undefined") {
+    // -a {positive number}
+    if (account < 0) {
+      throw new Error("Account number is required to be positive (including zero)");
+    }
+
+    // -a X -i Y or -a X --from-index Y --to-index Z
+    if (typeof index === "undefined" && (typeof fromIndex === "undefined" || typeof toIndex === "undefined") ) {
+      throw new Error("Index or range is required when account number option (`-a`) is enabled");
+    }
+
+    // -a X -i {positive number}
+    if (typeof index !== "undefined" && index < 0) {
+      throw new Error("Index number is required to be positive (including zero)");
+    }
+
+    if (typeof fromIndex !== "undefined" && typeof toIndex !== "undefined") {
+      // -a X --from-index {postive number} --to-index {postive number}
+      if (fromIndex < 0 || toIndex < 0) {
+        throw new Error("Range option is required to contain positive (including zero) numbers");
+      }
+
+      // -a X --from-index Y --to-index Z | Y <= Z
+      if (fromIndex > toIndex) {
+        throw new Error("--from-index has to be less or equal to --to-index");
+      }
+    }
+  }
+  else {
+    // -a X -i Y
+    if (typeof index !== "undefined") {
+      throw new Error("Account number is required when index number option (`-i`) is enabled");
+    }
+
+    // -a X --from-index Y --to-index Z
+    if (typeof fromIndex !== "undefined" || typeof toIndex !== "undefined") {
+      throw new Error("Account number is required when range index option (`--from-index`, `--to-index`) is enabled");
+    }
   }
 };

--- a/src/input/check.ts
+++ b/src/input/check.ts
@@ -112,23 +112,34 @@ export const checkArgs = (args: TODO_TypeThis): void => {
   if (typeof account !== "undefined") {
     // -a {positive number}
     if (account < 0) {
-      throw new Error("Account number is required to be positive (including zero)");
+      throw new Error(
+        "Account number is required to be positive (including zero)",
+      );
     }
 
     // -a X -i Y or -a X --from-index Y --to-index Z
-    if (typeof index === "undefined" && (typeof fromIndex === "undefined" || typeof toIndex === "undefined") ) {
-      throw new Error("Index or range is required when account number option (`-a`) is enabled");
+    if (
+      typeof index === "undefined" &&
+      (typeof fromIndex === "undefined" || typeof toIndex === "undefined")
+    ) {
+      throw new Error(
+        "Index or range is required when account number option (`-a`) is enabled",
+      );
     }
 
     // -a X -i {positive number}
     if (typeof index !== "undefined" && index < 0) {
-      throw new Error("Index number is required to be positive (including zero)");
+      throw new Error(
+        "Index number is required to be positive (including zero)",
+      );
     }
 
     if (typeof fromIndex !== "undefined" && typeof toIndex !== "undefined") {
       // -a X --from-index {postive number} --to-index {postive number}
       if (fromIndex < 0 || toIndex < 0) {
-        throw new Error("Range option is required to contain positive (including zero) numbers");
+        throw new Error(
+          "Range option is required to contain positive (including zero) numbers",
+        );
       }
 
       // -a X --from-index Y --to-index Z | Y <= Z
@@ -136,16 +147,19 @@ export const checkArgs = (args: TODO_TypeThis): void => {
         throw new Error("--from-index has to be less or equal to --to-index");
       }
     }
-  }
-  else {
+  } else {
     // -a X -i Y
     if (typeof index !== "undefined") {
-      throw new Error("Account number is required when index number option (`-i`) is enabled");
+      throw new Error(
+        "Account number is required when index number option (`-i`) is enabled",
+      );
     }
 
     // -a X --from-index Y --to-index Z
     if (typeof fromIndex !== "undefined" || typeof toIndex !== "undefined") {
-      throw new Error("Account number is required when range index option (`--from-index`, `--to-index`) is enabled");
+      throw new Error(
+        "Account number is required when range index option (`--from-index`, `--to-index`) is enabled",
+      );
     }
   }
 };

--- a/src/input/check.ts
+++ b/src/input/check.ts
@@ -117,11 +117,8 @@ export const checkArgs = (args: TODO_TypeThis): void => {
       );
     }
 
-    // -a X -i Y or -a X --from-index Y --to-index Z
-    if (
-      typeof index === "undefined" &&
-      (typeof fromIndex === "undefined" || typeof toIndex === "undefined")
-    ) {
+    // -a X -i Y or -a X --from-index Y [--to-index Z]
+    if (typeof index === "undefined" && typeof fromIndex === "undefined") {
       throw new Error(
         "Index or scanLimits is required when account number option (`-a`) is enabled",
       );
@@ -134,17 +131,23 @@ export const checkArgs = (args: TODO_TypeThis): void => {
       );
     }
 
-    if (typeof fromIndex !== "undefined" && typeof toIndex !== "undefined") {
-      // -a X --from-index {postive number} --to-index {postive number}
-      if (fromIndex < 0 || toIndex < 0) {
+    if (typeof fromIndex !== "undefined") {
+      // -a X --from-index {postive number} [--to-index {postive number}]
+      if (fromIndex < 0) {
         throw new Error(
-          "ScanLimits option is required to contain positive (including zero) numbers",
+          "--from-index option is required to be positive (including zero)",
         );
       }
 
-      // -a X --from-index Y --to-index Z | Y <= Z
-      if (fromIndex > toIndex) {
-        throw new Error("--from-index has to be less or equal to --to-index");
+      if (typeof toIndex !== "undefined") {
+        if (toIndex < 0) {
+          throw new Error("--to-index option is required to be positive");
+        }
+
+        // -a X --from-index Y --to-index Z | Y <= Z
+        if (fromIndex > toIndex) {
+          throw new Error("--from-index has to be less or equal to --to-index");
+        }
       }
     }
   } else {
@@ -156,9 +159,9 @@ export const checkArgs = (args: TODO_TypeThis): void => {
     }
 
     // -a X --from-index Y --to-index Z
-    if (typeof fromIndex !== "undefined" || typeof toIndex !== "undefined") {
+    if (typeof fromIndex !== "undefined") {
       throw new Error(
-        "Account number is required when scanLimits index option (`--from-index`, `--to-index`) is enabled",
+        "Account number is required when scanLimits index option (`--from-index`) is enabled",
       );
     }
   }
@@ -171,10 +174,7 @@ export const checkArgs = (args: TODO_TypeThis): void => {
         indexFrom: index,
         indexTo: index,
       };
-    } else if (
-      typeof fromIndex !== "undefined" &&
-      typeof toIndex !== "undefined"
-    ) {
+    } else if (typeof fromIndex !== "undefined") {
       args.scanLimits = {
         account,
         indexFrom: fromIndex,

--- a/src/input/check.ts
+++ b/src/input/check.ts
@@ -21,6 +21,7 @@ export const checkArgs = (args: TODO_TypeThis): void => {
   const index = args.index;
   const fromIndex = args.fromIndex;
   const toIndex = args.toIndex;
+  const preDerivationSize = args.preDerivationSize;
 
   // xpub: set, non-empty
   if (typeof xpub === "undefined" || xpub === "") {
@@ -161,9 +162,19 @@ export const checkArgs = (args: TODO_TypeThis): void => {
     // -a X --from-index Y --to-index Z
     if (typeof fromIndex !== "undefined") {
       throw new Error(
+        "--pre-derivation-size option is required to be positive",
+      );
+    }
+  }
+
+  if (typeof preDerivationSize !== "undefined") {
+    if (preDerivationSize < 0) {
+      throw new Error(
         "Account number is required when scanLimits index option (`--from-index`) is enabled",
       );
     }
+  } else if (typeof account !== "undefined") {
+    args.preDerivationSize = 2000; // magic number
   }
 
   // if needed, create scanLimits
@@ -173,12 +184,14 @@ export const checkArgs = (args: TODO_TypeThis): void => {
         account,
         indexFrom: index,
         indexTo: index,
+        preDerivationSize: args.preDerivationSize,
       };
     } else if (typeof fromIndex !== "undefined") {
       args.scanLimits = {
         account,
         indexFrom: fromIndex,
         indexTo: toIndex,
+        preDerivationSize: args.preDerivationSize,
       };
     }
   }

--- a/src/models/scanLimits.ts
+++ b/src/models/scanLimits.ts
@@ -2,6 +2,7 @@ class ScanLimits {
   account: number;
   indexFrom: number;
   indexTo: number;
+  preDerivationSize: number;
 }
 
 export { ScanLimits };

--- a/src/models/scanLimits.ts
+++ b/src/models/scanLimits.ts
@@ -1,0 +1,7 @@
+class ScanLimits {
+  account: number;
+  indexFrom: number;
+  indexTo: number;
+}
+
+export { ScanLimits };

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -70,6 +70,8 @@ async function scan() {
       comparisonResults = checkImportedOperations(
         importedTransactions,
         actualTransactions,
+        actualAddresses, // scan limits
+        typeof scanLimits === "undefined",
       );
     }
 
@@ -81,7 +83,7 @@ async function scan() {
     ) {
       mode = `m/${args.account}/${args.index}`;
     } else if (typeof scanLimits !== "undefined") {
-      mode = `range: account ${args.account}, indices ${scanLimits.from}⟶${scanLimits.to}`;
+      mode = `range: account ${scanLimits.account}, indices ${scanLimits.indexFrom}⟶${scanLimits.indexTo}`;
     } else {
       mode = "Full";
     }

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -81,11 +81,15 @@ async function scan() {
       typeof args.account !== "undefined" &&
       typeof args.index !== "undefined"
     ) {
-      mode = `m/${args.account}/${args.index}`;
+      mode = `Specific derivation path - m/${args.account}/${args.index}`;
     } else if (typeof scanLimits !== "undefined") {
-      mode = `range: account ${scanLimits.account}, indices ${scanLimits.indexFrom}⟶${scanLimits.indexTo}`;
+      let upperLimit = "∞";
+      if (typeof scanLimits.indexTo !== "undefined") {
+        upperLimit = scanLimits.indexTo;
+      }
+      mode = `Partial range — account ${scanLimits.account}, indices ${scanLimits.indexFrom}⟶${upperLimit}`;
     } else {
-      mode = "Full";
+      mode = "Full scan";
     }
 
     const meta = {

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -80,11 +80,8 @@ async function scan() {
       typeof args.index !== "undefined"
     ) {
       mode = `m/${args.account}/${args.index}`;
-<<<<<<< HEAD
     } else if (typeof scanLimits !== "undefined") {
       mode = `range: account ${args.account}, indices ${scanLimits.from}⟶${scanLimits.to}`;
-=======
->>>>>>> upstream/master
     } else {
       mode = "Full";
     }

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -64,6 +64,8 @@ async function scan() {
 
     display.showResults(actualUTXOs, actualTransactions, summary);
 
+    const partialScan = typeof scanLimits !== "undefined";
+
     let comparisonResults;
 
     if (typeof importedTransactions !== "undefined") {
@@ -71,7 +73,7 @@ async function scan() {
         importedTransactions,
         actualTransactions,
         actualAddresses, // scan limits
-        typeof scanLimits === "undefined",
+        partialScan, // scan limits
       );
     }
 

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -98,7 +98,7 @@ async function scan() {
       date: now,
       version: VERSION,
       mode,
-      preDerivationSize: args.preDerivationSize
+      preDerivationSize: args.preDerivationSize,
     };
 
     const data = {

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -21,11 +21,10 @@ const VERSION = "0.1.0";
 const args = getArgs();
 
 const scanLimits = args.scanLimits;
-
 const address = args.address;
 const currency = args.currency;
-
 const xpub = String(args._[0]);
+
 init(xpub, args.silent, args.quiet, currency);
 
 const now = new Date();
@@ -99,6 +98,7 @@ async function scan() {
       date: now,
       version: VERSION,
       mode,
+      preDerivationSize: args.preDerivationSize
     };
 
     const data = {

--- a/src/templates/report.html.ts
+++ b/src/templates/report.html.ts
@@ -20,6 +20,17 @@ export const reportTemplate = `
         font-family: FreeMono, monospace;
       }
 
+      #warning_range {
+        margin: 0 auto;
+        padding: 4px;
+        border: 2px solid #E51C10;
+        background-color: #FFB3B3;
+        width: 90%;
+        text-align: center;
+        font-family: Georgia, serif;
+        font-style: italic;
+      }
+
       .meta {
         font-size: 1em;
         margin: 2em;
@@ -259,6 +270,8 @@ export const reportTemplate = `
         <li><strong>Xpub Scan version:</strong> {version}</li>
       </ul>
     </div>
+
+    {warning_range}</br>
 
     <ul class="tabs">
 

--- a/src/templates/report.html.ts
+++ b/src/templates/report.html.ts
@@ -266,7 +266,7 @@ export const reportTemplate = `
         <li><strong>Analysis date:</strong> {analysis_date}</li>
         <li><strong>Provider:</strong> {provider} ({provider_url})</li>
         <li><strong>Gap limit:</strong> {gap_limit}</li>
-        <li><strong>Scan mode:</strong> {mode}</li>
+        <li><strong>Scan mode:</strong> {mode} {pre_derivation_size}</li>
         <li><strong>Xpub Scan version:</strong> {version}</li>
       </ul>
     </div>


### PR DESCRIPTION
New scan mode allowing to do a _partial_ scan.

- Specific derivation path (_i.e._, `m/X/Y`): `$ xpub-scan {xpub} --account X --index Y`
- Specific range of indices (_i.e._, `m/X/Y` → `m/X/Z`): `$ xpub-scan {xpub} --account X --from-index Y --to-index Z`
- Scan from a lower limit (up to no active address, gap limit notwithstanding) (_i.e._, `m/X/Y` → `m/X/∞`): `$ xpub-scan {xpub} --account X --from-index Y`

Note: a warning appears in the HTML and JSON reports when the analysis results are based on such a range.
<img width="749" alt="warning 2" src="https://user-images.githubusercontent.com/66550865/117310841-f50ab300-ae83-11eb-8693-bab53a301e4a.png">

<img width="1374" alt="warning" src="https://user-images.githubusercontent.com/66550865/117310653-c260ba80-ae83-11eb-9722-f91625e35f3e.png">

---
**Warning**: in this mode, Xpub Scan has to pre-derive a certain number of addresses. It is by default 2,000. Effectively, 2,000 addresses will be pre-derived _for each account number_. If an xpub contains more than 2,000 active addresses for a given account number, the results of the analysis will be erroneous. To avoid such a situation, this number can be adjusted with the `pre-derivation-size` option.

