### PR TITLE
Handle Aggregated Operations and Operations Sorting Enhancement

### DIFF
--- a/src/actions/saveAnalysis.ts
+++ b/src/actions/saveAnalysis.ts
@@ -311,6 +311,11 @@ function makeComparisonsTable(object: TODO_TypeThis, onlyDiff?: boolean) {
           continue; // if diff: ignore matches
         }
         comparisons.push('<tr class="comparison_match">');
+      } else if (e.status.includes("aggregated")) {
+        if (onlyDiff) {
+          continue; // if diff: ignore aggregated operations
+        }
+        comparisons.push('<tr class="comparison_aggregated">');
       } else {
         comparisons.push('<tr class="comparison_mismatch">');
       }

--- a/src/comparison/compareOperations.ts
+++ b/src/comparison/compareOperations.ts
@@ -210,6 +210,7 @@ const showOperations = (
       break;
   }
 };
+
 /**
  * Check whether operations are aggregated or not
  * @param  {Operation} importedOp
@@ -247,8 +248,6 @@ const areAggregated = (
  *          Actual operations
  * @returns Comparison
  *          Result of the comparison
- *
- * TODO: handle aggregated operations
  */
 const checkImportedOperations = (
   importedOperations: Operation[],
@@ -267,7 +266,7 @@ const checkImportedOperations = (
     );
   }
 
-  const allComparingCriteria: ComparingCriterion[] = []; // TODO: convert into a Set as they have to be unique
+  const allComparingCriteria: ComparingCriterion[] = [];
   const comparisons: Comparison[] = [];
 
   // filter imported operations if scan is limited (range scan)

--- a/src/comparison/compareOperations.ts
+++ b/src/comparison/compareOperations.ts
@@ -61,8 +61,8 @@ const compareOps = (A: Operation, B: Operation): number => {
  * @param  {Operation} actualOperation
  *          An actual operation
  * @returns boolean
- *          true if operations are matching
- *          false if operations are not matching
+ *          `true` if operations are matching
+ *          `false` if operations are not matching
  */
 const areMatching = (
   importedOperation: Operation,
@@ -210,7 +210,16 @@ const showOperations = (
       break;
   }
 };
-
+/**
+ * Check whether operations are aggregated or not
+ * @param  {Operation} importedOp
+ *          An imported operation
+ * @param  {Operation[]} actualOps
+ *          List of actual operations
+ * @returns boolean
+ *          `true` if operations are aggregated
+ *          `false` if operations are not aggregated
+ */
 const areAggregated = (
   importedOp: Operation,
   actualOps: Operation[],

--- a/src/comparison/compareOperations.ts
+++ b/src/comparison/compareOperations.ts
@@ -23,7 +23,16 @@ interface ComparingCriterion {
  *           1 if A < B
  *           0 if A == B
  */
-const compareOpsByAmountThenAddress = (A: Operation, B: Operation): number => {
+const compareOps = (A: Operation, B: Operation): number => {
+  // date
+  if (A.date > B.date) {
+    return -1;
+  }
+
+  if (A.date < B.date) {
+    return 1;
+  }
+
   // amount
   if (A.amount > B.amount) {
     return -1;
@@ -67,7 +76,8 @@ const areMatching = (
   // be used
   if (
     importedAddress &&
-    !importedAddress.includes(actualOperation.getAddress())
+    !importedAddress.includes(actualOperation.getAddress()) &&
+    !actualOperation.getAddress().includes(importedAddress)
   ) {
     return false;
   }
@@ -135,6 +145,8 @@ const showOperations = (
   switch (status) {
     case "Match":
     /* fallthrough */
+    case "Match (aggregated)":
+    /* fallthrough */
     case "Mismatch":
       imported = A.date
         .padEnd(24, " ")
@@ -165,6 +177,14 @@ const showOperations = (
         .concat(renderAddress(A.address))
         .concat(String(A.amount));
       break;
+    case "Missing (aggregated)":
+      imported = "(aggregated operation)";
+
+      actual = A.date
+        .padEnd(24, " ")
+        .concat(renderAddress(A.address))
+        .concat(String(A.amount));
+      break;
   }
 
   switch (status) {
@@ -173,6 +193,11 @@ const showOperations = (
         chalk.greenBright(imported.padEnd(halfColorPadding, " ")),
         actual,
       );
+      break;
+    case "Match (aggregated)":
+    /* fallthrough */
+    case "Missing (aggregated)":
+      console.log(chalk.green(imported.padEnd(halfColorPadding, " ")), actual);
       break;
     case "Mismatch":
     /* fallthrough */
@@ -184,6 +209,25 @@ const showOperations = (
       );
       break;
   }
+};
+
+const areAggregated = (
+  importedOp: Operation,
+  actualOps: Operation[],
+): boolean => {
+  if (typeof importedOp === "undefined") {
+    return false;
+  }
+
+  const actual = actualOps.filter((op) => op.txid === importedOp.txid);
+
+  if (actual.length < 2) {
+    return false;
+  }
+
+  const totalAmount = actual.reduce((a, b) => a + b.amount, 0);
+
+  return totalAmount === importedOp.amount;
 };
 
 /**
@@ -298,15 +342,68 @@ const checkImportedOperations = (
       }
     }
 
-    // sort both arrays of operations to ease the comparison
-    importedOps.sort(compareOpsByAmountThenAddress);
-    actualOps.sort(compareOpsByAmountThenAddress);
+    // sort I (common cases): compare by date, amount, address
+    importedOps.sort(compareOps);
+    actualOps.sort(compareOps);
+
+    // sort II (edge cases):
+    // sort operations with same txid, same date, and same amount
+    // that cannot be sorted by address
+    for (const criterion of allComparingCriteria) {
+      const imported = importedOps.filter((op) => op.txid === criterion.hash);
+
+      // if only one imported operation have this txid, skip
+      if (imported.length < 2 || typeof criterion.hash === "undefined") {
+        continue;
+      }
+
+      for (let i = 0; i < imported.length; ++i) {
+        for (let j = 0; j < actualOps.length; ++j) {
+          // if an actual operation having the same txid
+          // has an identical address...
+          if (
+            actualOps[j].txid === imported[i].txid &&
+            imported[i].address.includes(actualOps[j].address)
+          ) {
+            // ... swap it with the first actual operation
+            [actualOps[0], actualOps[j]] = [actualOps[j], actualOps[0]];
+            break;
+          }
+        }
+      }
+    }
+
+    const aggregatedTxids: string[] = [];
 
     // Math.max(...) used here because the imported and actual arrays do not
     // necessarily have the same size (i.e. missing operations)
     for (let i = 0; i < Math.max(importedOps.length, actualOps.length); ++i) {
       const importedOp = importedOps[i];
       const actualOp = actualOps[i];
+
+      // aggregated operations
+      // (fixes https://github.com/LedgerHQ/xpub-scan/issues/23)
+      if (
+        typeof actualOp !== "undefined" &&
+        (aggregatedTxids.includes(actualOp.txid) ||
+          areAggregated(importedOp, actualOps))
+      ) {
+        aggregatedTxids.push(actualOp.txid);
+
+        if (typeof importedOp !== "undefined") {
+          showOperations("Match (aggregated)", importedOp, actualOp);
+        } else {
+          showOperations("Missing (aggregated)", actualOp);
+        }
+
+        comparisons.push({
+          imported: importedOp,
+          actual: actualOp,
+          status: "Match (aggregated)",
+        });
+
+        continue;
+      }
 
       // actual operation with no corresponding imported operation
       if (typeof importedOp === "undefined") {

--- a/src/comparison/compareOperations.ts
+++ b/src/comparison/compareOperations.ts
@@ -261,7 +261,7 @@ const checkImportedOperations = (
   const allComparingCriteria: ComparingCriterion[] = []; // TODO: convert into a Set as they have to be unique
   const comparisons: Comparison[] = [];
 
-  // filter imported operations if scan is limited
+  // filter imported operations if scan is limited (range scan)
   if (partialComparison) {
     const rangeAddresses = actualAddresses.map((address) => address.toString());
 

--- a/src/models/comparison.ts
+++ b/src/models/comparison.ts
@@ -2,6 +2,8 @@ import { Operation } from "./operation";
 
 type ComparisonStatus =
   | "Match" // perfect match between imported and actual operation
+  | "Match (aggregated)" // aggregated operation
+  | "Missing (aggregated)" // aggregation operation (resulting missing imported operation)
   | "Mismatch" // address or amount mismatch
   | "Missing Operation" // missing expected imported operation
   | "Extra Operation"; // imported operation without corresponding actual operation

--- a/src/templates/report.html.ts
+++ b/src/templates/report.html.ts
@@ -109,6 +109,10 @@ export const reportTemplate = `
         color: #cc0000 !important;
       }
 
+      .comparison_aggregated {
+        color: #000080 !important;
+      }
+
       strong {
         font-weight: bold;
       }


### PR DESCRIPTION
- Fixes https://github.com/LedgerHQ/xpub-scan/issues/23
- Orders operations having the same txid, date, and amount

Now, aggregated operations are rendered as such instead of being labeled as diffs. For instance:

**Before: aggregated operations were labeled as erroneous operations**

_HTML report (red color, labeled as erroneous operations):_ 
<img width="1295" alt="Before" src="https://user-images.githubusercontent.com/66550865/117939574-7c36ab80-b308-11eb-99c2-34e015dc6b89.png">

_(on the left, the imported operation; on the right, the two corresponding actual operations)_

**After**
_HTML report (blue color, labeled as aggregated):_

<img width="1310" alt="After" src="https://user-images.githubusercontent.com/66550865/117939594-8062c900-b308-11eb-83da-dc85948dc88a.png">

_(on the left, the imported operation; on the right, the two corresponding actual operations)_

_Json:_

```
{
      "imported": {
        "date": "2020-09-26 09:36:23",
        "amount": "1094",
        "txid": "ff8d90a32c4ce48ac76b1b8332c4cc5f91e55b3b393d757d28d53574c4d2a210",
        "address": "1BhkR9PyKi3j9A13Mkh4gB2Gf79pAXVQg7",
        "operationType": "Received"
      },
      "actual": {
        "date": "2020-09-26 11:36:27",
        "amount": "547",
        "txid": "ff8d90a32c4ce48ac76b1b8332c4cc5f91e55b3b393d757d28d53574c4d2a210",
        "block": 650053,
        "operationType": "Received (non-sibling to change)",
        "address": "1DkpyZhZN4JYEZtziQ2rwh9UKur5WE5BKA"
      },
      "status": "Match (aggregated)"
    }
```
