### PR TITLE
Select derivation mode

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,3 +1,7 @@
 {
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "endOfLine": "lf",
+  "printWidth": 80,
+  "tabWidth": 2,
+  "arrowParens": "always"
 }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Given a master public key (xpub, Ltub, _etc._), get the balances of its derived 
 - Privacy Friendly: master public keys are never sent over the Internet: only their derived addresses are
 - Derives specific addresses (by account+index) or all active ones
 - Searches if a given address has been derived from a given master public key (perfect and partial match)
-- Supports legacy, SegWit, and Native Segwit
+- Supports legacy, SegWit, and Native SegWit
 - Automatically checks some categories of CSV files containing operations history
 
 ## Prerequisites

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/xpub-scan",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Master public key analysis tool",
   "bin": {
     "xpub-scan": "./lib/scan.js"

--- a/src/actions/checkAddress.ts
+++ b/src/actions/checkAddress.ts
@@ -1,6 +1,6 @@
 import chalk from "chalk";
 
-import { getAddressType, getAddress } from "./deriveAddresses";
+import { getDerivationMode, getAddress } from "./deriveAddresses";
 import { DERIVATION_SCOPE } from "../configuration/settings";
 import { TODO_TypeThis } from "../types";
 
@@ -88,7 +88,7 @@ function search(
   range: TODO_TypeThis,
   searchType: string,
 ): Result {
-  const addressType = getAddressType(providedAddress);
+  const derivationMode = getDerivationMode(providedAddress);
   const partialSearch = providedAddress.includes("?");
 
   for (
@@ -97,7 +97,7 @@ function search(
     ++account
   ) {
     for (let index = range.index.min; index < range.index.max; ++index) {
-      const derivedAddress = getAddress(addressType, xpub, account, index);
+      const derivedAddress = getAddress(derivationMode, xpub, account, index);
 
       // m/{account}/{index}
       const derivationPath = "m/".concat(account).concat("/").concat(index);

--- a/src/actions/checkBalance.ts
+++ b/src/actions/checkBalance.ts
@@ -144,7 +144,16 @@ async function run(xpub: string, scanLimits?: ScanLimits) {
   let activeAddresses: Address[] = [];
   const summary: TODO_TypeThis[] = [];
 
-  const derivationModes = configuration.currency.derivationModes;
+  let derivationModes = configuration.currency.derivationModes;
+
+  if (configuration.specificDerivationMode) {
+    // if a specific derivation mode is set, limit the scan to this mode
+    derivationModes = derivationModes.filter(
+      (d) =>
+        d.toString().toLocaleLowerCase() ===
+        configuration.specificDerivationMode.toLocaleLowerCase(),
+    );
+  }
 
   if (!configuration.silent) {
     console.log(chalk.bold("\nActive addresses\n"));

--- a/src/actions/checkBalance.ts
+++ b/src/actions/checkBalance.ts
@@ -148,10 +148,11 @@ async function run(xpub: string, scanLimits?: ScanLimits) {
 
   if (configuration.specificDerivationMode) {
     // if a specific derivation mode is set, limit the scan to this mode
-    derivationModes = derivationModes.filter(
-      (d) =>
-        d.toString().toLocaleLowerCase() ===
-        configuration.specificDerivationMode.toLocaleLowerCase(),
+    derivationModes = derivationModes.filter((derivation) =>
+      derivation
+        .toString()
+        .toLocaleLowerCase()
+        .startsWith(configuration.specificDerivationMode.toLocaleLowerCase()),
     );
   }
 

--- a/src/actions/deriveAddresses.ts
+++ b/src/actions/deriveAddresses.ts
@@ -3,7 +3,7 @@ import * as bip32 from "bip32";
 import * as bch from "bitcoincashjs";
 import bchaddr from "bchaddrjs";
 
-import { AddressType } from "../configuration/currencies";
+import { DerivationMode } from "../configuration/currencies";
 import { configuration } from "../configuration/settings";
 
 // derive legacy address at account and index positions
@@ -80,19 +80,19 @@ function getLegacyBitcoinCashAddress(
 
 // get address given an address type
 function getAddress(
-  addressType: AddressType,
+  derivationMode: DerivationMode,
   xpub: string,
   account: number,
   index: number,
 ): string {
-  switch (addressType) {
-    case AddressType.LEGACY:
+  switch (derivationMode) {
+    case DerivationMode.LEGACY:
       return getLegacyAddress(xpub, account, index);
-    case AddressType.SEGWIT:
+    case DerivationMode.SEGWIT:
       return getSegWitAddress(xpub, account, index);
-    case AddressType.NATIVE:
+    case DerivationMode.NATIVE:
       return getNativeSegWitAddress(xpub, account, index);
-    case AddressType.BCH:
+    case DerivationMode.BCH:
       return getLegacyBitcoinCashAddress(xpub, account, index);
   }
 
@@ -104,13 +104,13 @@ function getAddress(
 // TODO: improve the prefix matching: make the expected prefix
 // correspond to the actual type (currently, a `ltc1` prefix
 // could match a native Bitcoin address type for instance)
-function getAddressType(address: string) {
+function getDerivationMode(address: string) {
   if (address.match("^(bc1|tb1|ltc1).*")) {
-    return AddressType.NATIVE;
+    return DerivationMode.NATIVE;
   } else if (address.match("^(3|2|M).*")) {
-    return AddressType.SEGWIT;
+    return DerivationMode.SEGWIT;
   } else if (address.match("^(1|n|m|L).*")) {
-    return AddressType.LEGACY;
+    return DerivationMode.LEGACY;
   } else {
     throw new Error(
       "INVALID ADDRESS: ".concat(address).concat(" is not a valid address"),
@@ -118,4 +118,4 @@ function getAddressType(address: string) {
   }
 }
 
-export { getAddressType, getAddress };
+export { getDerivationMode, getAddress };

--- a/src/actions/saveAnalysis.ts
+++ b/src/actions/saveAnalysis.ts
@@ -348,7 +348,16 @@ function saveHTML(object: TODO_TypeThis, filepath: string) {
   } else {
     report = report.replace(
       "{pre_derivation_size}",
-      `(pre-derivation size: ${object.meta.preDerivationSize})`,
+      `| pre-derivation size: ${object.meta.preDerivationSize}`,
+    );
+  }
+
+  if (typeof object.meta.derivationMode === "undefined") {
+    report = report.replace("{derivation_mode}", "");
+  } else {
+    report = report.replace(
+      "{derivation_mode}",
+      `| specific derivation mode: ${object.meta.derivationMode}`,
     );
   }
 
@@ -577,6 +586,7 @@ function save(meta: TODO_TypeThis, data: TODO_TypeThis, directory: string) {
       unit: "Base unit (i.e., satoshis or equivalent unit)",
       mode: meta.mode,
       preDerivationSize: meta.preDerivationSize,
+      derivationMode: meta.derivationMode,
       warningRange,
     },
     addresses,

--- a/src/actions/saveAnalysis.ts
+++ b/src/actions/saveAnalysis.ts
@@ -208,7 +208,7 @@ function makeUTXOSTable(object: TODO_TypeThis) {
   const utxos: string[] = [];
 
   for (const e of object.utxos) {
-    utxos.push("<tr><td>" + e.addressType + "</td>");
+    utxos.push("<tr><td>" + e.derivationMode + "</td>");
 
     const derivationPath =
       "m/" + e.derivation.account + "/" + e.derivation.index;
@@ -369,7 +369,7 @@ function saveHTML(object: TODO_TypeThis, filepath: string) {
   // summary
   const summary: string[] = [];
   for (const e of object.summary) {
-    summary.push("<tr><td>" + e.addressType + "</td>");
+    summary.push("<tr><td>" + e.derivationMode + "</td>");
 
     const balance = sb.toBitcoin(e.balance);
 
@@ -389,7 +389,7 @@ function saveHTML(object: TODO_TypeThis, filepath: string) {
   const addresses: string[] = [];
 
   for (const e of object.addresses) {
-    addresses.push("<tr><td>" + e.addressType + "</td>");
+    addresses.push("<tr><td>" + e.derivationMode + "</td>");
 
     const derivationPath =
       "m/" + e.derivation.account + "/" + e.derivation.index;
@@ -482,7 +482,7 @@ function save(meta: TODO_TypeThis, data: TODO_TypeThis, directory: string) {
   // convert amounts into base unit
   const addresses: TODO_TypeThis[] = data.addresses.map((e: TODO_TypeThis) => {
     return {
-      addressType: e.addressType,
+      derivationMode: e.derivationMode,
       derivation: e.getDerivation(),
       address: e.toString(),
       cashAddress: e.asCashAddress(),
@@ -496,7 +496,7 @@ function save(meta: TODO_TypeThis, data: TODO_TypeThis, directory: string) {
     .filter((a: Address) => a.isUTXO())
     .map((e: TODO_TypeThis) => {
       return {
-        addressType: e.addressType,
+        derivationMode: e.derivationMode,
         derivation: e.getDerivation(),
         address: e.toString(),
         cashAddress: e.asCashAddress(),

--- a/src/configuration/currencies.ts
+++ b/src/configuration/currencies.ts
@@ -3,7 +3,7 @@ import coininfo from "coininfo";
 export enum DerivationMode {
   LEGACY = "Legacy",
   NATIVE = "Native SegWit",
-  SEGWIT = "Segwit",
+  SEGWIT = "SegWit",
   BCH = "Bitcoin Cash",
 }
 

--- a/src/configuration/currencies.ts
+++ b/src/configuration/currencies.ts
@@ -1,11 +1,10 @@
 import coininfo from "coininfo";
 
 export enum DerivationMode {
-  LEGACY = "legacy",
-  NATIVE = "native",
-  SEGWIT = "segwit",
-  BCH = "bch",
-  UNKNOWN = "Unknown",
+  LEGACY = "Legacy",
+  NATIVE = "Native SegWit",
+  SEGWIT = "Segwit",
+  BCH = "Bitcoin Cash",
 }
 
 // TODO: complete migratation from settings to currencies

--- a/src/configuration/currencies.ts
+++ b/src/configuration/currencies.ts
@@ -1,12 +1,12 @@
 import coininfo from "coininfo";
 
-export enum AddressType {
+export enum DerivationMode {
   LEGACY = "Legacy",
   NATIVE = "Native SegWit",
   SEGWIT = "SegWit",
   BCH = "Bitcoin Cash",
 }
-Object.freeze(AddressType);
+Object.freeze(DerivationMode);
 
 // TODO: complete migratation from settings to currencies
 export const currencies = {
@@ -15,7 +15,7 @@ export const currencies = {
     symbol: "BTC",
     network_mainnet: coininfo.bitcoin.main.toBitcoinJS(),
     network_testnet: coininfo.bitcoin.test.toBitcoinJS(),
-    addressTypes: [AddressType.LEGACY, AddressType.SEGWIT, AddressType.NATIVE],
+    derivationModes: [DerivationMode.LEGACY, DerivationMode.SEGWIT, DerivationMode.NATIVE],
     precision: 100000000,
   },
   bch: {
@@ -23,7 +23,7 @@ export const currencies = {
     symbol: "BCH",
     network_mainnet: coininfo.bitcoincash.main.toBitcoinJS(),
     network_testnet: coininfo.bitcoincash.test.toBitcoinJS(),
-    addressTypes: [AddressType.BCH],
+    derivationModes: [DerivationMode.BCH],
     precision: 100000000,
   },
   ltc: {
@@ -31,7 +31,7 @@ export const currencies = {
     symbol: "LTC",
     network_mainnet: coininfo.litecoin.main.toBitcoinJS(),
     network_testnet: coininfo.litecoin.test.toBitcoinJS(),
-    addressTypes: [AddressType.LEGACY, AddressType.SEGWIT, AddressType.NATIVE],
+    derivationModes: [DerivationMode.LEGACY, DerivationMode.SEGWIT, DerivationMode.NATIVE],
     precision: 100000000,
   },
 };

--- a/src/configuration/currencies.ts
+++ b/src/configuration/currencies.ts
@@ -1,12 +1,12 @@
 import coininfo from "coininfo";
 
 export enum DerivationMode {
-  LEGACY = "Legacy",
-  NATIVE = "Native SegWit",
-  SEGWIT = "SegWit",
-  BCH = "Bitcoin Cash",
+  LEGACY = "legacy",
+  NATIVE = "native",
+  SEGWIT = "segwit",
+  BCH = "bch",
+  UNKNOWN = "Unknown",
 }
-Object.freeze(DerivationMode);
 
 // TODO: complete migratation from settings to currencies
 export const currencies = {
@@ -15,7 +15,11 @@ export const currencies = {
     symbol: "BTC",
     network_mainnet: coininfo.bitcoin.main.toBitcoinJS(),
     network_testnet: coininfo.bitcoin.test.toBitcoinJS(),
-    derivationModes: [DerivationMode.LEGACY, DerivationMode.SEGWIT, DerivationMode.NATIVE],
+    derivationModes: [
+      DerivationMode.LEGACY,
+      DerivationMode.SEGWIT,
+      DerivationMode.NATIVE,
+    ],
     precision: 100000000,
   },
   bch: {
@@ -31,7 +35,11 @@ export const currencies = {
     symbol: "LTC",
     network_mainnet: coininfo.litecoin.main.toBitcoinJS(),
     network_testnet: coininfo.litecoin.test.toBitcoinJS(),
-    derivationModes: [DerivationMode.LEGACY, DerivationMode.SEGWIT, DerivationMode.NATIVE],
+    derivationModes: [
+      DerivationMode.LEGACY,
+      DerivationMode.SEGWIT,
+      DerivationMode.NATIVE,
+    ],
     precision: 100000000,
   },
 };

--- a/src/configuration/settings.ts
+++ b/src/configuration/settings.ts
@@ -65,6 +65,7 @@ dotenv.config();
 export const configuration = {
   currency: new Currency(),
   testnet: false,
+  specificDerivationMode: "",
   externalProviderURL: "",
   APIKey: process.env.XPUB_SCAN_CUSTOM_API_KEY,
   providerType: "default",

--- a/src/display.ts
+++ b/src/display.ts
@@ -35,7 +35,7 @@ function updateAddressDetails(address: Address) {
     return;
   }
 
-  const addressType = address.getType();
+  const derivationMode = address.getDerivationMode();
   const account = address.getDerivation().account;
   const index = address.getDerivation().index;
 
@@ -50,7 +50,7 @@ function updateAddressDetails(address: Address) {
   let stats =
     //    _{address type}_  {derivation path}  {address}  [{cash address}]...
     "  "
-      .concat(chalk.italic(addressType.padEnd(16, " ")))
+      .concat(chalk.italic(derivationMode.padEnd(16, " ")))
       .concat(derivationPath.padEnd(12, " "));
 
   const cashAddress = address.asCashAddress();
@@ -168,7 +168,7 @@ function showSortedOperations(sortedOperations: Operation[]) {
       // ... -{amount} →|⮂|↺
       status = status.concat("-").concat(amount);
 
-      const operationType = op.getType();
+      const operationType = op.getDerivationMode();
 
       if (operationType === "Sent to self") {
         // case 1. Sent to the same address
@@ -191,7 +191,7 @@ function showSortedOperations(sortedOperations: Operation[]) {
 }
 
 // display the summary: total balance by address type
-function showSummary(addressType: string, totalBalance: number) {
+function showSummary(derivationMode: string, totalBalance: number) {
   if (configuration.silent) {
     return;
   }
@@ -200,12 +200,14 @@ function showSummary(addressType: string, totalBalance: number) {
 
   if (balance === "0") {
     console.log(
-      chalk.grey(addressType.padEnd(16, " ").concat(balance.padEnd(12, " "))),
+      chalk.grey(
+        derivationMode.padEnd(16, " ").concat(balance.padEnd(12, " ")),
+      ),
     );
   } else {
     console.log(
       chalk
-        .whiteBright(addressType.padEnd(16, " "))
+        .whiteBright(derivationMode.padEnd(16, " "))
         .concat(chalk.greenBright(balance.padEnd(12, " "))),
     );
   }
@@ -257,7 +259,7 @@ function showResults(
 
   console.log(chalk.bold("\nSummary\n"));
   for (const total of summary) {
-    showSummary(total.addressType, total.balance);
+    showSummary(total.derivationMode, total.balance);
   }
 }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -135,6 +135,7 @@ function init(
   quiet: boolean,
   currency?: string,
   testnet?: boolean,
+  derivationMode?: string,
 ) {
   configuration.silent = silent;
   configuration.quiet = quiet;
@@ -142,6 +143,8 @@ function init(
   setNetwork(xpub, currency, testnet);
   setExternalProviderURL();
   checkXpub(xpub);
+
+  configuration.specificDerivationMode = derivationMode!;
 }
 
 // remove prefixes (`bitcoincash:`) from Bitcoin Cash addresses

--- a/src/input/args.ts
+++ b/src/input/args.ts
@@ -54,6 +54,11 @@ export const getArgs = (): TODO_TypeThis => {
       demand: false,
       type: "string",
     })
+    .option("derivation-mode", {
+      description: "Select specific derivation mode (legacy, SegWit, etc.)",
+      demand: false,
+      type: "string",
+    })
     // stdout options
     .option("silent", {
       description:

--- a/src/input/check.ts
+++ b/src/input/check.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import chalk from "chalk";
 
-import { currencies } from "../configuration/currencies";
+import { currencies, DerivationMode } from "../configuration/currencies";
 import { TODO_TypeThis } from "../types";
 
 /**
@@ -18,6 +18,7 @@ export const checkArgs = (args: TODO_TypeThis): void => {
   const balance = args.balance;
   const save = args.save;
   const currency = args.currency;
+  const derivationMode = args.derivationMode;
   const account = args.account;
   const index = args.index;
   const fromIndex = args.fromIndex;
@@ -52,6 +53,37 @@ export const checkArgs = (args: TODO_TypeThis): void => {
     if (currencyProperties.length === 0) {
       throw new Error(
         "Currency '" + currency + "' has not been implemented yet",
+      );
+    }
+  }
+
+  // derivation mode: compatible with (implicitly) selected currency
+  if (typeof derivationMode !== "undefined") {
+    let availableDerivationModes: Array<DerivationMode>;
+
+    if (typeof currency !== "undefined") {
+      // if currency is defined, explicitly use its derivation modes
+      availableDerivationModes = Object.entries(currencies)
+        .filter(
+          (c) => c[1].symbol.toUpperCase() === args.currency.toUpperCase(),
+        )
+        .map((c) => {
+          return c[1].derivationModes;
+        })[0];
+    } else {
+      // if currency is not defined, implicitly use BTC's derivation modes
+      availableDerivationModes = currencies.btc.derivationModes;
+    }
+
+    if (
+      availableDerivationModes.filter((d) =>
+        d.toLocaleLowerCase().includes(derivationMode.toLocaleLowerCase()),
+      ).length === 0
+    ) {
+      throw new Error(
+        "Selected derivation mode " +
+          derivationMode +
+          " is not compatible with selected currency",
       );
     }
   }

--- a/src/input/check.ts
+++ b/src/input/check.ts
@@ -77,7 +77,7 @@ export const checkArgs = (args: TODO_TypeThis): void => {
 
     if (
       availableDerivationModes.filter((d) =>
-        d.toLocaleLowerCase().includes(derivationMode.toLocaleLowerCase()),
+        d.toLocaleLowerCase().startsWith(derivationMode.toLocaleLowerCase()),
       ).length === 0
     ) {
       throw new Error(

--- a/src/models/address.ts
+++ b/src/models/address.ts
@@ -1,15 +1,14 @@
 import { configuration } from "../configuration/settings";
-import { AddressType } from "../configuration/currencies";
+import { currencies, DerivationMode } from "../configuration/currencies";
 import { Transaction } from "./transaction";
 import { Operation } from "./operation";
 import { Stats } from "./stats";
 import { getAddress } from "../actions/deriveAddresses";
 import { toUnprefixedCashAddress } from "../helpers";
-import { currencies } from "../configuration/currencies";
 
 class Address {
   address: string;
-  addressType: AddressType;
+  derivationMode: DerivationMode;
   account: number;
   index: number;
   balance: number;
@@ -21,13 +20,13 @@ class Address {
   utxo: boolean;
 
   constructor(
-    addressType: AddressType,
+    derivationMode: DerivationMode,
     xpub: string,
     account: number,
     index: number,
   ) {
-    this.address = getAddress(addressType, xpub, account, index);
-    this.addressType = addressType;
+    this.address = getAddress(derivationMode, xpub, account, index);
+    this.derivationMode = derivationMode;
     this.account = account;
     this.index = index;
     this.ins = [];
@@ -87,8 +86,8 @@ class Address {
     return undefined;
   }
 
-  getType() {
-    return this.addressType;
+  getDerivationMode() {
+    return this.derivationMode;
   }
 
   getDerivation() {

--- a/src/models/currency.ts
+++ b/src/models/currency.ts
@@ -1,11 +1,11 @@
-import { AddressType } from "../configuration/currencies";
+import { DerivationMode } from "../configuration/currencies";
 import { TODO_TypeThis } from "../types";
 
 class Currency {
   name: string;
   symbol: string;
   network?: TODO_TypeThis;
-  addressTypes: Array<AddressType>;
+  derivationModes: Array<DerivationMode>;
   precision: number;
 }
 

--- a/src/models/operation.ts
+++ b/src/models/operation.ts
@@ -1,7 +1,7 @@
 type OperationType =
   | "Received" // Received - common case
   | "Received (non-sibling to change)" // Received - edge case: address not belonging to the xpub
-  //                       sending funds to change address
+  //                                                            sending funds to change address
   | "Sent" // Sent - common case
   | "Sent to self" // Sent - edge case 1: The recipient is the sender (identity)
   | "Sent to sibling"; // Sent - edge case 2: recipient belongs to same xpub ("sibling")

--- a/src/models/operation.ts
+++ b/src/models/operation.ts
@@ -56,7 +56,7 @@ class Operation {
     this.operationType = operationType;
   }
 
-  getType() {
+  getDerivationMode() {
     return this.operationType;
   }
 }

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -2,7 +2,7 @@
 
 import chalk from "chalk";
 
-import * as check_balances from "./actions/checkBalance";
+import * as checkBalances from "./actions/checkBalance";
 import * as compare from "./actions/checkAddress";
 import * as display from "./display";
 import {
@@ -16,7 +16,7 @@ import { importOperations } from "./input/importOperations";
 import { save } from "./actions/saveAnalysis";
 import { getArgs } from "./input/args";
 
-const VERSION = "0.3.6";
+const VERSION = "0.3.7";
 
 const args = getArgs();
 
@@ -24,9 +24,10 @@ const scanLimits = args.scanLimits;
 const address = args.address;
 const currency = args.currency;
 const testnet = args.testnet;
+const derivationMode = args.derivationMode;
 const xpub = String(args._[0]);
 
-init(xpub, args.silent, args.quiet, currency, testnet);
+init(xpub, args.silent, args.quiet, currency, testnet, derivationMode);
 
 const now = new Date();
 
@@ -56,7 +57,7 @@ async function scan() {
       importedTransactions = importOperations(args.operations);
     }
 
-    const scanResult = await check_balances.run(xpub, scanLimits);
+    const scanResult = await checkBalances.run(xpub, scanLimits);
     const actualAddresses = scanResult.addresses;
     const actualUTXOs = getSortedUTXOS(actualAddresses);
     const summary = scanResult.summary;

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -15,6 +15,7 @@ import { checkImportedOperations } from "./comparison/compareOperations";
 import { importOperations } from "./input/importOperations";
 import { save } from "./actions/saveAnalysis";
 import { getArgs } from "./input/args";
+import { configuration } from "./configuration/settings";
 
 const VERSION = "0.3.7";
 
@@ -101,6 +102,7 @@ async function scan() {
       version: VERSION,
       mode,
       preDerivationSize: args.preDerivationSize,
+      derivationMode: configuration.specificDerivationMode,
     };
 
     const data = {

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -17,7 +17,8 @@ import { save } from "./actions/saveAnalysis";
 import { getArgs } from "./input/args";
 import { configuration } from "./configuration/settings";
 
-const VERSION = "0.3.7";
+// eslint-disable-next-line
+const { version } = require("../package.json");
 
 const args = getArgs();
 
@@ -99,7 +100,7 @@ async function scan() {
     const meta = {
       xpub,
       date: now,
-      version: VERSION,
+      version,
       mode,
       preDerivationSize: args.preDerivationSize,
       derivationMode: configuration.specificDerivationMode,

--- a/src/templates/report.html.ts
+++ b/src/templates/report.html.ts
@@ -270,7 +270,7 @@ export const reportTemplate = `
         <li><strong>Analysis date:</strong> {analysis_date}</li>
         <li><strong>Provider:</strong> {provider} ({provider_url})</li>
         <li><strong>Gap limit:</strong> {gap_limit}</li>
-        <li><strong>Scan mode:</strong> {mode} {pre_derivation_size}</li>
+        <li><strong>Scan mode:</strong> {mode} {pre_derivation_size} {derivation_mode}</li>
         <li><strong>Xpub Scan version:</strong> {version}</li>
       </ul>
     </div>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -69,6 +69,9 @@
 
     /* Advanced Options */
     "skipLibCheck": true /* Skip type checking of declaration files. */,
-    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
-  }
+    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
+    "resolveJsonModule": true
+  },
+  "include": ["./src"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Currently, Xpub Scan scans _all_ derivation modes related to a currency (e.g., Bitcoin legacy, Bitcoin SegWit, and Bitcoin Native SegWit).

This is not necessary when the derivation mode is known beforehand.

In this context, this implementation allows to specify a derivation mode: `--derivation-mode {derivation mode in one word}`

The current supported derivation modes are:

| Derivation mode        | Option           |
| ------------- |:-------------:|
| Legacy    | `legacy` | 
| SegWit      | `segwit`      |
| Native SegWit | `native`      |

For instance:

| Derivation mode needed        | Option           |
| ------------- |:-------------:|
| Litecoin Legacy    | `xpub-scan {ltub} --derivation-mode legacy` | 
| Bitcoin SegWit      | `xpub-scan {xpub} --derivation-mode segwit`      |
| Bitcoin Native SegWit | `xpub-scan {xpub} --derivation-mode native`      |