### PR TITLE
Fix Operations Comparison: Edge Case Ordering + Migrate to Custom Provider v2

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,2 +1,2 @@
-XPUB_SCAN_CUSTOM_API_URL=https://provider.com/{coin}/address/{address}
-XPUB_SCAN_CUSTOM_API_KEY=<your api key>
+XPUB_SCAN_CUSTOM_API_URL_V2=https://provider.com/{coin}/address/{address}
+XPUB_SCAN_CUSTOM_API_KEY_V2=<your api key>

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ The derived addresses are displayed during the analysis. Perfect matches are dis
 ### Change External Provider
 
 1. At the root of the project, rename `.env.template` to `.env`
-2. In `.env`, set the `XPUB_SCAN_CUSTOM_API_URL` as well as your `XPUB_SCAN_CUSTOM_API_KEY` (following the structure provided by the `.env.template`)
+2. In `.env`, set the `XPUB_SCAN_CUSTOM_API_URL_V2` as well as your `XPUB_SCAN_CUSTOM_API_KEY_V2` (following the structure provided by the `.env.template`)
 3. rebuild the tool: `$ yarn build`
 4. Re-run it: `$ node ./lib/scan.js <xpub> …`
 5. Ensure that, when running the tool, it shows that the _custom_ provider is being used

--- a/src/actions/processTransactions.ts
+++ b/src/actions/processTransactions.ts
@@ -79,7 +79,7 @@ function processFundedTransactions(
         const op = new Operation(tx.date, tx.ins[0].amount);
         op.setTxid(tx.txid);
         op.setBlockNumber(tx.blockHeight);
-        op.setType(
+        op.setOperationType(
           accountNumber !== 1 ? "Received" : "Received (non-sibling to change)",
         );
 
@@ -110,13 +110,13 @@ function processSentTransactions(address: Address, ownAddresses: OwnAddresses) {
 
         if (out.address === address.toString()) {
           // sent to self: sent to same address
-          op.setType("Sent to self");
+          op.setOperationType("Sent to self");
         } else if (externalAddresses.includes(out.address)) {
           // sent to a sibling: sent to an address belonging to the same xpub
           // while not being a change address
-          op.setType("Sent to sibling");
+          op.setOperationType("Sent to sibling");
         } else {
-          op.setType("Sent");
+          op.setOperationType("Sent");
         }
 
         op.setBlockNumber(tx.blockHeight);

--- a/src/actions/saveAnalysis.ts
+++ b/src/actions/saveAnalysis.ts
@@ -237,8 +237,8 @@ function makeComparisonsTable(object: TODO_TypeThis, onlyDiff?: boolean) {
     <table>
         <thead>
             <tr style="text-align: center">
-                <th rowspan="1" colspan="3">Imported</th>
-                <th rowspan="1" colspan="3">Actual</th>
+                <th rowspan="1" colspan="3">Imported (from product)</th>
+                <th rowspan="1" colspan="3">Actual (from external provider)</th>
                 <th rowspan="2" colspan="1">TXID</th>
                 <th rowspan="2" colspan="1">Type</th>
                 <th rowspan="2" colspan="1">Status</th>

--- a/src/api/customProvider.ts
+++ b/src/api/customProvider.ts
@@ -152,7 +152,7 @@ function getTransactions(address: Address) {
 
           op.setAddress(inAddress);
           op.setTxid(tx.txid);
-          op.setType("Received");
+          op.setOperationType("Received");
 
           ins.push(op);
         });
@@ -175,7 +175,7 @@ function getTransactions(address: Address) {
 
           op.setAddress(outAddress);
           op.setTxid(tx.txid);
-          op.setType("Sent");
+          op.setOperationType("Sent");
 
           outs.push(op);
         });

--- a/src/api/defaultProvider.ts
+++ b/src/api/defaultProvider.ts
@@ -145,7 +145,7 @@ function getTransactions(address: Address) {
         );
         op.setAddress(txin.address);
         op.setTxid(tx.txid);
-        op.setType("Received");
+        op.setOperationType("Received");
 
         ins.push(op);
       });
@@ -156,7 +156,7 @@ function getTransactions(address: Address) {
         const op = new Operation(String(tx.time), parseFloat(txout.value));
         op.setAddress(txout.address);
         op.setTxid(tx.txid);
-        op.setType("Sent");
+        op.setOperationType("Sent");
 
         outs.push(op);
       });
@@ -220,7 +220,7 @@ function getBchTransactions(address: Address) {
         const op = new Operation(String(tx.time), amount);
         op.setAddress(txin.addr);
         op.setTxid(tx.txid);
-        op.setType("Received");
+        op.setOperationType("Received");
 
         ins.push(op);
       });
@@ -234,7 +234,7 @@ function getBchTransactions(address: Address) {
         const op = new Operation(String(tx.time), parseFloat(txout.value));
         op.setAddress(txout.scriptPubKey.addresses[0]);
         op.setTxid(tx.txid);
-        op.setType("Sent");
+        op.setOperationType("Sent");
 
         outs.push(op);
       });

--- a/src/comparison/compareOperations.ts
+++ b/src/comparison/compareOperations.ts
@@ -371,20 +371,20 @@ const checkImportedOperations = (
           // but the operation types or addresses differ...
           if (
             // [ an actual operation has the same txid,
-            actualOps[i].txid === importedOp.txid &&
-            // and:
-            // 1. the operation type is the same {use of
-            //    `startsWith` as the actual operation types are
-            //    a superset of imported operation types:
-            //       - Send (to self, to sibling);
-            //       - Received ((non-sibling to change))},
-            actualOps[i]
-              .getOperationType()
-              .startsWith(importedOp.getOperationType()) &&
+            (actualOps[i].txid === importedOp.txid &&
+              // and:
+              // 1. the operation type is the same {use of
+              //    `startsWith` as the actual operation types are
+              //    a superset of imported operation types:
+              //       - Send (to self, to sibling);
+              //       - Received ((non-sibling to change))},
+              !actualOps[i]
+                .getOperationType()
+                .startsWith(importedOp.getOperationType())) ||
             // ans
             // 2. the imported operation does include the actual
             //    address (`oncludes`: imported addresses can be aggregated) ]
-            importedOp.address.includes(actualOps[i].address)
+            !importedOp.address.includes(actualOps[i].address)
           ) {
             // ... then swap it with first actual operation
             [actualOps[0], actualOps[i]] = [actualOps[i], actualOps[0]];

--- a/src/comparison/compareOperations.ts
+++ b/src/comparison/compareOperations.ts
@@ -365,16 +365,29 @@ const checkImportedOperations = (
         continue;
       }
 
-      for (let i = 0; i < imported.length; ++i) {
-        for (let j = 0; j < actualOps.length; ++j) {
-          // if an actual operation having the same txid
-          // has an identical address...
+      for (const importedOp of imported) {
+        for (let i = 0; i < actualOps.length; ++i) {
+          // if an actual operation is having the same txid,
+          // but the operation types or addresses differ...
           if (
-            actualOps[j].txid === imported[i].txid &&
-            imported[i].address.includes(actualOps[j].address)
+            // [ an actual operation has the same txid,
+            actualOps[i].txid === importedOp.txid &&
+            // and:
+            // 1. the operation type is the same {use of
+            //    `startsWith` as the actual operation types are
+            //    a superset of imported operation types:
+            //       - Send (to self, to sibling);
+            //       - Received ((non-sibling to change))},
+            actualOps[i]
+              .getOperationType()
+              .startsWith(importedOp.getOperationType()) &&
+            // ans
+            // 2. the imported operation does include the actual
+            //    address (`oncludes`: imported addresses can be aggregated) ]
+            importedOp.address.includes(actualOps[i].address)
           ) {
-            // ... swap it with the first actual operation
-            [actualOps[0], actualOps[j]] = [actualOps[j], actualOps[0]];
+            // ... then swap it with first actual operation
+            [actualOps[0], actualOps[i]] = [actualOps[i], actualOps[0]];
             break;
           }
         }

--- a/src/configuration/settings.ts
+++ b/src/configuration/settings.ts
@@ -67,7 +67,7 @@ export const configuration = {
   testnet: false,
   specificDerivationMode: "",
   externalProviderURL: "",
-  APIKey: process.env.XPUB_SCAN_CUSTOM_API_KEY,
+  APIKey: process.env.XPUB_SCAN_CUSTOM_API_KEY_V2,
   providerType: "default",
   silent: false,
   quiet: false,

--- a/src/display.ts
+++ b/src/display.ts
@@ -168,7 +168,7 @@ function showSortedOperations(sortedOperations: Operation[]) {
       // ... -{amount} →|⮂|↺
       status = status.concat("-").concat(amount);
 
-      const operationType = op.getDerivationMode();
+      const operationType = op.getOperationType();
 
       if (operationType === "Sent to self") {
         // case 1. Sent to the same address

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -104,11 +104,11 @@ function setNetwork(xpub: string, currency?: string, testnet?: boolean) {
 const setExternalProviderURL = (): void => {
   // custom provider (i.e., API key is set)
   if (
-    process.env.XPUB_SCAN_CUSTOM_API_URL &&
-    process.env.XPUB_SCAN_CUSTOM_API_KEY
+    process.env.XPUB_SCAN_CUSTOM_API_URL_V2 &&
+    process.env.XPUB_SCAN_CUSTOM_API_KEY_V2
   ) {
     configuration.externalProviderURL =
-      process.env.XPUB_SCAN_CUSTOM_API_URL.replace(
+      process.env.XPUB_SCAN_CUSTOM_API_URL_V2.replace(
         "{network}",
         configuration.testnet ? "testnet" : "mainnet",
       );

--- a/src/input/importOperations.ts
+++ b/src/input/importOperations.ts
@@ -89,7 +89,7 @@ const importFromCSVTypeA = (contents: string): Operation[] => {
           // ensure that an operation without address results in a mismatch
           op.setAddress(sanitizeInputedAddress(recipient));
 
-          op.setType("Received");
+          op.setOperationType("Received");
 
           operations.push(op);
         } else if (type === "DEBIT") {
@@ -102,7 +102,7 @@ const importFromCSVTypeA = (contents: string): Operation[] => {
           // ensure that an operation without address results in a mismatch
           op.setAddress(sanitizeInputedAddress(sender));
 
-          op.setType("Sent");
+          op.setOperationType("Sent");
 
           operations.push(op);
         }
@@ -145,7 +145,7 @@ const importFromCSVTypeB = (contents: string): Operation[] => {
       if (type === "IN") {
         const op = new Operation(date[0], amount);
         op.setTxid(txid);
-        op.setType("Received");
+        op.setOperationType("Received");
 
         operations.push(op);
       } else if (type === "OUT") {
@@ -155,7 +155,7 @@ const importFromCSVTypeB = (contents: string): Operation[] => {
         // (otherwise, there would be floating number issues)
         const op = new Operation(date[0], sb.toBitcoin(amountInSatoshis));
         op.setTxid(txid);
-        op.setType("Sent");
+        op.setOperationType("Sent");
 
         operations.push(op);
       }
@@ -197,7 +197,7 @@ const importFromJSONTypeA = (contents: string): Operation[] => {
     if (type === "receive") {
       const op = new Operation(date[0], sb.toBitcoin(valueInSatoshis));
       op.setTxid(txid);
-      op.setType("Received");
+      op.setOperationType("Received");
 
       const addresses = [];
       for (const output of operation.transaction.outputs) {
@@ -216,7 +216,7 @@ const importFromJSONTypeA = (contents: string): Operation[] => {
       // (otherwise, there would be floating number issues)
       const op = new Operation(date[0], sb.toBitcoin(amountInSatoshis));
       op.setTxid(txid);
-      op.setType("Sent");
+      op.setOperationType("Sent");
 
       const addresses = [];
       for (const input of operation.transaction.inputs) {
@@ -267,7 +267,7 @@ const importFromJSONTypeB = (contents: string): Operation[] => {
     if (type === "IN") {
       const op = new Operation(date[0], sb.toBitcoin(valueInSatoshis));
       op.setTxid(txid);
-      op.setType("Received");
+      op.setOperationType("Received");
       op.setAddress(sanitizeInputedAddress(recipient));
 
       operations.push(op);
@@ -278,7 +278,7 @@ const importFromJSONTypeB = (contents: string): Operation[] => {
       // (otherwise, there would be floating number issues)
       const op = new Operation(date[0], sb.toBitcoin(amountInSatoshis));
       op.setTxid(txid);
-      op.setType("Sent");
+      op.setOperationType("Sent");
       op.setAddress(sanitizeInputedAddress(sender));
 
       operations.push(op);
@@ -318,7 +318,7 @@ const importFromJSONTypeC = (contents: string): Operation[] => {
 
     if (type === "RECEIVE") {
       const op = new Operation(date[0], sb.toBitcoin(valueInSatoshis));
-      op.setType("Received");
+      op.setOperationType("Received");
 
       op.setTxid(txid);
 
@@ -333,7 +333,7 @@ const importFromJSONTypeC = (contents: string): Operation[] => {
     } else if (type === "SEND") {
       const op = new Operation(date[0], sb.toBitcoin(valueInSatoshis));
 
-      op.setType("Sent");
+      op.setOperationType("Sent");
 
       op.setTxid(txid);
 

--- a/src/models/operation.ts
+++ b/src/models/operation.ts
@@ -52,11 +52,11 @@ class Operation {
     return this.address;
   }
 
-  setType(operationType: OperationType) {
+  setOperationType(operationType: OperationType) {
     this.operationType = operationType;
   }
 
-  getDerivationMode() {
+  getOperationType() {
     return this.operationType;
   }
 }


### PR DESCRIPTION
**WIP**

**1. Operations Comparison Fix**

In some specific cases, the actual operations are not well ordered vis-à-vis imported operations. The edge case context is the following one:

- Multiple operations with the same txid,
- With the same amount
- But with different operation types (sent v. received)

**2. Custom Provider v2**

Migration to custom provider v2.

**This is a WIP that remains to be thoroughly tested.**