### PR TITLE
New `--custom-provider` Option

### DIFF
--- a/src/input/args.ts
+++ b/src/input/args.ts
@@ -110,6 +110,12 @@ export const getArgs = (): TODO_TypeThis => {
       description: "Save analysis",
       demand: false,
       type: "string",
+    })
+    .option("custom-provider", {
+      description: "Require the use of the custom provider",
+      demand: false,
+      type: "boolean",
+      default: false,
     }).argv;
 
   checkArgs(args, process.argv);

--- a/src/input/check.ts
+++ b/src/input/check.ts
@@ -258,4 +258,10 @@ export const checkArgs = (args: TODO_TypeThis, argv: string[]): void => {
       );
     }
   }
+
+  if (args.customProvider && !process.env.XPUB_SCAN_CUSTOM_API_KEY_V2) {
+    throw new Error(
+      "Custom provider v2 API key (XPUB_SCAN_CUSTOM_API_KEY_V2) is missing",
+    );
+  }
 };


### PR DESCRIPTION
New `--custom-provider` option to require the use of the **custom** provider instead of the default one.

When used, if the API key is missing, the following error is thrown:

```
Error: Custom provider v2 API key (XPUB_SCAN_CUSTOM_API_KEY_V2) is missing
```