### PR TITLE
Fix Undefined Raw Transactions

### DIFF
--- a/src/models/address.ts
+++ b/src/models/address.ts
@@ -114,7 +114,13 @@ class Address {
   }
 
   getRawTransactions() {
-    return this.rawTransactions;
+    const rawTransactions = this.rawTransactions;
+
+    if (typeof rawTransactions === "undefined") {
+      return "[]"; // if no transaction, return an empty stringified JSON array
+    } else {
+      return rawTransactions;
+    }
   }
 
   isUTXO() {


### PR DESCRIPTION
Fix errors occurring when raw transactions were undefined (no transaction associated to a given account).