### PR TITLE
Fix JSON Report: Summary Balance

### DIFF
--- a/src/actions/saveAnalysis.ts
+++ b/src/actions/saveAnalysis.ts
@@ -526,7 +526,7 @@ function save(meta: TODO_TypeThis, data: TODO_TypeThis, directory: string) {
   const summary: TODO_TypeThis[] = data.summary.map((e: TODO_TypeThis) => {
     return {
       ...e,
-      balance: e.balance,
+      balance: toBaseUnit(new BigNumber(e.balance)),
     };
   });
 

--- a/src/actions/saveAnalysis.ts
+++ b/src/actions/saveAnalysis.ts
@@ -377,7 +377,7 @@ function saveHTML(object: TODO_TypeThis, filepath: string) {
       summary.push("<tr><td>" + configuration.currency.name + "</td>");
     }
 
-    const balance = e.balance;
+    const balance = toAccountUnit(new BigNumber(e.balance));
 
     if (balance === "0") {
       summary.push('<td class="summary_empty">');

--- a/src/comparison/diffs.ts
+++ b/src/comparison/diffs.ts
@@ -1,8 +1,6 @@
 import BigNumber from "bignumber.js";
 import chalk from "chalk";
-import { currencies } from "../configuration/currencies";
-import { configuration, ETH_FIXED_PRECISION } from "../configuration/settings";
-import { toAccountUnit, toBaseUnit, toUnprefixedCashAddress } from "../helpers";
+import { toBaseUnit, toUnprefixedCashAddress } from "../helpers";
 import { Comparison } from "../models/comparison";
 
 /**
@@ -68,19 +66,8 @@ const showDiff = (
 
   // check balance
   if (importedBalance) {
-    let imported = "";
-    let actual = "";
-
-    // the actual balance has to be converted into base unit
-    if (configuration.currency.utxo_based) {
-      imported = new BigNumber(importedBalance).toFixed();
-      actual = toBaseUnit(new BigNumber(actualBalance));
-    } else if (configuration.currency.symbol === currencies.eth.symbol) {
-      // ETH: use fixed-point notation
-      // imported balance has to be converted into unit of account
-      imported = toAccountUnit(new BigNumber(importedBalance));
-      actual = new BigNumber(actualBalance).toFixed(ETH_FIXED_PRECISION);
-    }
+    const imported = new BigNumber(importedBalance).toFixed(0);
+    const actual = toBaseUnit(new BigNumber(actualBalance));
 
     if (imported !== actual) {
       console.log(chalk.redBright("Diff [ KO ]: balances mismatch"));


### PR DESCRIPTION
Fix the summary balance in the JSON report (regression: was expressed in terms of units of account instead of base units) and unify the diff balance rendering.