### PR TITLE
Fix Ethereum-related Issues

### DIFF
--- a/src/actions/saveAnalysis.ts
+++ b/src/actions/saveAnalysis.ts
@@ -164,6 +164,12 @@ function createTooltip(opType: string) {
             Sent to another address, belonging to the same xpub (sibling)
         </span>
         `;
+  } else if (opType === "Failed to send") {
+    tooltip = `
+        <span class="tooltiptext">
+            Send operation failed (it can impact the balance)
+        </span>
+        `;
   }
 
   return '<div class="tooltip">' + opType + tooltip + "</div>";
@@ -303,7 +309,12 @@ function makeComparisonsTable(object: TODO_TypeThis, onlyDiff?: boolean) {
         if (onlyDiff) {
           continue; // if diff: ignore matches
         }
-        comparisons.push('<tr class="comparison_match">');
+
+        if (e.operationType !== "Sent (failed") {
+          comparisons.push('<tr class="comparison_match">');
+        } else {
+          comparisons.push('<tr class="failed_operation">');
+        }
       } else if (e.status.includes("aggregated")) {
         if (onlyDiff) {
           continue; // if diff: ignore aggregated operations
@@ -435,7 +446,12 @@ function saveHTML(object: TODO_TypeThis, filepath: string) {
 
   const transactions: string[] = [];
   for (const e of object.transactions) {
-    transactions.push("<tr><td>" + e.date + "</td>");
+    transactions.push(
+      e.operationType === "Failed to send"
+        ? '<tr class="failed_operation">'
+        : "<tr>",
+    );
+    transactions.push("<td>" + e.date + "</td>");
     transactions.push("<td>" + e.block + "</td>");
     transactions.push("<td>" + renderTxid(e.txid) + "</td>");
     transactions.push(

--- a/src/actions/saveAnalysis.ts
+++ b/src/actions/saveAnalysis.ts
@@ -310,10 +310,10 @@ function makeComparisonsTable(object: TODO_TypeThis, onlyDiff?: boolean) {
           continue; // if diff: ignore matches
         }
 
-        if (e.operationType !== "Sent (failed") {
-          comparisons.push('<tr class="comparison_match">');
-        } else {
+        if (opType === "Failed to send") {
           comparisons.push('<tr class="failed_operation">');
+        } else {
+          comparisons.push('<tr class="comparison_match">');
         }
       } else if (e.status.includes("aggregated")) {
         if (onlyDiff) {

--- a/src/api/customProvider.ts
+++ b/src/api/customProvider.ts
@@ -257,9 +257,10 @@ function getAccountBasedTransactions(address: Address) {
 
     if (isSender) {
       // Sender
-      const amount = tx.recipients.reduce((a, b) => +a + +b.amount, 0);
+      const amount = new BigNumber(
+        tx.recipients.reduce((a, b) => +a + +b.amount, 0),
+      );
       const fixedAmount = amount.toFixed(ETH_FIXED_PRECISION);
-
       const op = new Operation(timestamp, new BigNumber(fixedAmount)); // ETH: use fixed-point notation
       op.setAddress(address.toString());
       op.setTxid(tx.transactionId);

--- a/src/comparison/compareOperations.ts
+++ b/src/comparison/compareOperations.ts
@@ -193,6 +193,13 @@ const showOperations = (
       break;
   }
 
+  if (
+    A.operationType === "Failed to send" ||
+    B?.operationType === "Failed to send"
+  ) {
+    actual = chalk.blueBright(actual.concat(" [failed]"));
+  }
+
   switch (status) {
     case "Match":
       console.log(

--- a/src/display.ts
+++ b/src/display.ts
@@ -184,8 +184,11 @@ function showSortedOperations(sortedOperations: Operation[]) {
         // case 2. Sent to a sibling address
         // (different non-change address belonging to same xpub)
         status = status.concat(" ↺");
+      } else if (operationType === "Failed to send") {
+        // case 3. Failed to send (Ethereum)
+        status = status.concat(" x");
       } else {
-        // case 3. Sent to external address
+        // case 4. Sent to external address
         status = status.concat(" →");
       }
     }

--- a/src/models/operation.ts
+++ b/src/models/operation.ts
@@ -6,7 +6,8 @@ type OperationType =
   //                                                            sending funds to change address
   | "Sent" // Sent - common case
   | "Sent to self" // Sent - edge case 1: The recipient is the sender (identity)
-  | "Sent to sibling"; // Sent - edge case 2: recipient belongs to same xpub ("sibling")
+  | "Sent to sibling" // Sent - edge case 2: recipient belongs to same xpub ("sibling")
+  | "Failed to send"; // Sent - edge case 3: failed send operation that impacts the balance (fees) (Ethereum)
 
 class Operation {
   operationType: OperationType;
@@ -61,6 +62,11 @@ class Operation {
 
   setOperationType(operationType: OperationType) {
     this.operationType = operationType;
+
+    // if the operation has failed, set its amount to 0
+    if (operationType === "Failed to send") {
+      this.amount = new BigNumber(0);
+    }
   }
 
   getOperationType() {

--- a/src/templates/report.html.ts
+++ b/src/templates/report.html.ts
@@ -106,7 +106,7 @@ export const reportTemplate = `
       }
 
       .failed_operation {
-        color: #5C0471 !important;
+        color: #4e2cb1 !important;
       }
 
       .comparison_mismatch {

--- a/src/templates/report.html.ts
+++ b/src/templates/report.html.ts
@@ -105,6 +105,10 @@ export const reportTemplate = `
         font-weight: bold !important;
       }
 
+      .failed_operation {
+        color: #5C0471 !important;
+      }
+
       .comparison_mismatch {
         color: #cc0000 !important;
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,7 +21,7 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.15.0.tgz#2dbaf8b85334796cafbb0f5793a90a2fc010b176"
   integrity sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==
 
-"@babel/core@^7.1.0", "@babel/core@^7.14.6", "@babel/core@^7.7.2", "@babel/core@^7.7.5":
+"@babel/core@^7.1.0", "@babel/core@^7.15.5", "@babel/core@^7.7.2", "@babel/core@^7.7.5":
   version "7.15.5"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.15.5.tgz#f8ed9ace730722544609f90c9bb49162dc3bf5b9"
   integrity sha512-pYgXxiwAgQpgM1bNkZsDEq85f0ggXMA5L7c+o3tskGMh2BunCI9QUwB9Z4jpvXUOuMdyGKiGKQiRe11VS6Jzvg==
@@ -42,7 +42,7 @@
     semver "^6.3.0"
     source-map "^0.5.0"
 
-"@babel/eslint-parser@^7.14.7":
+"@babel/eslint-parser@^7.15.4":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.15.4.tgz#46385943726291fb3e8db99522c8099b15684387"
   integrity sha512-hPMIAmGNbmQzXJIo2P43Zj9UhRmGev5f9nqdBFOWNGDGh6XKmjby79woBvg6y0Jur6yRfQBneDbUQ8ZVc1krFw==
@@ -785,7 +785,7 @@
     "@babel/helper-create-regexp-features-plugin" "^7.14.5"
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/preset-env@^7.14.7":
+"@babel/preset-env@^7.15.6":
   version "7.15.6"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.15.6.tgz#0f3898db9d63d320f21b17380d8462779de57659"
   integrity sha512-L+6jcGn7EWu7zqaO2uoTDjjMBW+88FXzV8KvrBl2z6MtRNxlsmUNRlZPaNNPUTgqhyC5DHNFk/2Jmra+ublZWw==
@@ -875,7 +875,7 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
-"@babel/preset-typescript@^7.14.5":
+"@babel/preset-typescript@^7.15.0":
   version "7.15.0"
   resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.15.0.tgz#e8fca638a1a0f64f14e1119f7fe4500277840945"
   integrity sha512-lt0Y/8V3y06Wq/8H/u0WakrqciZ7Fz7mwPDHWUJAXlABL5hiUG42BNlRXiELNjeWjO5rWmnNKlx+yzJvxezHow==
@@ -1293,7 +1293,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/html-minifier@^4.0.0":
+"@types/html-minifier@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/html-minifier/-/html-minifier-4.0.1.tgz#9486ffc144f8d7b8f75b07939c500ac3d73617a0"
   integrity sha512-6u58FWQbWP45bsxVeMJo0yk2LEsjjZsCwn0JDe/i5Edk3L+b9TR5eZ2FGaMCrLdtGYpME5AGxUqv8o+3hWKogw==
@@ -1334,7 +1334,7 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
 
-"@types/minimist@^1.2.1":
+"@types/minimist@^1.2.2":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
@@ -1390,7 +1390,7 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^4.28.2":
+"@typescript-eslint/eslint-plugin@^4.31.0":
   version "4.31.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.31.0.tgz#9c3fa6f44bad789a962426ad951b54695bd3af6b"
   integrity sha512-iPKZTZNavAlOhfF4gymiSuUkgLne/nh5Oz2/mdiUmuZVD42m9PapnCnzjxuDsnpnbH3wT5s2D8bw6S39TC6GNw==
@@ -1415,7 +1415,7 @@
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
-"@typescript-eslint/parser@^4.28.2":
+"@typescript-eslint/parser@^4.31.0":
   version "4.31.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.31.0.tgz#87b7cd16b24b9170c77595d8b1363f8047121e05"
   integrity sha512-oWbzvPh5amMuTmKaf1wp0ySxPt2ZXHnFQBN2Szu1O//7LmOvgaKTCIDNLK2NvzpmVd5A2M/1j/rujBqO37hj3w==
@@ -1634,7 +1634,7 @@ aws4@^1.6.0, aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axios@^0.21.1:
+axios@^0.21.4:
   version "0.21.4"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
   integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
@@ -2071,7 +2071,7 @@ cashaddrjs@^0.2.7, cashaddrjs@^0.2.8:
   dependencies:
     big-integer "^1.6.34"
 
-chalk@*, chalk@^4.0.0, chalk@^4.1.1:
+chalk@*, chalk@^4.0.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -2516,7 +2516,7 @@ eslint-visitor-keys@^2.0.0, eslint-visitor-keys@^2.1.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
-eslint@^7.30.0:
+eslint@^7.32.0:
   version "7.32.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.32.0.tgz#c6d328a14be3fb08c8d1d21e12c02fdb7a2a812d"
   integrity sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==
@@ -3585,7 +3585,7 @@ jest-worker@^27.1.1:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jest@^27.0.6:
+jest@^27.1.1:
   version "27.1.1"
   resolved "https://registry.yarnpkg.com/jest/-/jest-27.1.1.tgz#49f0497fa0fb07dc78898318cc1b737b5fbf72d8"
   integrity sha512-LFTEZOhoZNR/2DQM3OCaK5xC6c55c1OWhYh0njRsoHX0qd6x4nkcgenkSH0JKjsAGMTmmJAoL7/oqYHMfwhruA==
@@ -4725,7 +4725,7 @@ tr46@^2.1.0:
   dependencies:
     punycode "^2.1.1"
 
-ts-node@^10.0.0:
+ts-node@^10.2.1:
   version "10.2.1"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.2.1.tgz#4cc93bea0a7aba2179497e65bb08ddfc198b3ab5"
   integrity sha512-hCnyOyuGmD5wHleOQX6NIjJtYVIO8bPP8F2acWkB4W06wdlkgyvJtubO/I9NkI88hCFECbsEgoLc0VNkYmcSfw==
@@ -4808,7 +4808,7 @@ typeforce@^1.11.3, typeforce@^1.11.5:
   resolved "https://registry.yarnpkg.com/typeforce/-/typeforce-1.18.0.tgz#d7416a2c5845e085034d70fcc5b6cc4a90edbfdc"
   integrity sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==
 
-typescript@^4.3.5:
+typescript@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.2.tgz#6d618640d430e3569a1dfb44f7d7e600ced3ee86"
   integrity sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==
@@ -5041,7 +5041,7 @@ yargs@^16.0.3:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^17.0.1:
+yargs@^17.1.1:
   version "17.1.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.1.1.tgz#c2a8091564bdb196f7c0a67c1d12e5b85b8067ba"
   integrity sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==


### PR DESCRIPTION
Fix some Ethereum-related issues:

1. Fix erroneous amounts mismatches (edge cases: rounding error)
2. Take into account failed _ougoing_ Ethereum operations (as they can impact the balance). 

From the CLI, failed outgoing operations are now identified with a `x`:

```
2021-04-21 09:44:42 	12282306	0x0000EF2F047F8b07c6C0000FD1A13438E9d0000	-0   x
2021-04-20 21:27:53 	12278942	0x0000EF2F047F8b07c6C0000FD1A13438E9d0000	-123 →
2021-04-20 21:27:17 	12278939	0x0000EF2F047F8b07c6C0000FD1A13438E9d0000	-0   x
2021-04-20 21:25:11 	12278932	0x0000EF2F047F8b07c6C0000FD1A13438E9d0000	-345 →
2021-04-19 20:16:49 	12272042	0x0000EF2F047F8b07c6C0000FD1A13438E9d0000	-678 →
2021-04-19 20:08:47 	12272004	0x0000EF2F047F8b07c6C0000FD1A13438E9d0000	-0   x
```

In the HTML report, failed outgoing operations are identified with a purple color:

<img width="1322" alt="failed eth ops" src="https://user-images.githubusercontent.com/66550865/133059248-9e2bc492-881b-496f-8b6c-e23ce993db24.png">

In the JSON report, failed outgoing operations are identified with a `Failed to send` label: 

```
    {
      "date": "2021-04-21 09:44:42",
      "amount": "0",
      "address": "0x0000EF2F047F8b07c6C0000FD1A13438E9d0000",
      "txid": "0x0000...",
      "operationType": "Failed to send",
      "block": 12282306
    },
```
