### PR TITLE
Support Ethereum Token Operations

### DIFF
--- a/src/actions/saveAnalysis.ts
+++ b/src/actions/saveAnalysis.ts
@@ -170,6 +170,12 @@ function createTooltip(opType: string) {
             Send operation failed (it can impact the balance)
         </span>
         `;
+  } else if (opType.includes("token")) {
+    tooltip = `
+        <span class="tooltiptext">
+            Ethereum token (e.g. ERC20) related operation
+        </span>
+        `;
   }
 
   return '<div class="tooltip">' + opType + tooltip + "</div>";

--- a/src/actions/saveAnalysis.ts
+++ b/src/actions/saveAnalysis.ts
@@ -312,6 +312,8 @@ function makeComparisonsTable(object: TODO_TypeThis, onlyDiff?: boolean) {
 
         if (opType === "Failed to send") {
           comparisons.push('<tr class="failed_operation">');
+        } else if (opType.includes("token")) {
+          comparisons.push('<tr class="token_operation">');
         } else {
           comparisons.push('<tr class="comparison_match">');
         }
@@ -446,11 +448,15 @@ function saveHTML(object: TODO_TypeThis, filepath: string) {
 
   const transactions: string[] = [];
   for (const e of object.transactions) {
-    transactions.push(
-      e.operationType === "Failed to send"
-        ? '<tr class="failed_operation">'
-        : "<tr>",
-    );
+    let rowStyle = "<tr>";
+
+    if (e.operationType === "Failed to send") {
+      rowStyle = '<tr class="failed_operation">';
+    } else if (e.operationType.includes("token")) {
+      rowStyle = '<tr class="token_operation">';
+    }
+
+    transactions.push(rowStyle);
     transactions.push("<td>" + e.date + "</td>");
     transactions.push("<td>" + e.block + "</td>");
     transactions.push("<td>" + renderTxid(e.txid) + "</td>");

--- a/src/api/customProvider.ts
+++ b/src/api/customProvider.ts
@@ -78,7 +78,9 @@ async function getPayloads(
   // to handle large number of transactions by address, use the index+limit logic
   // offered by the custom provider
   let offset = 0;
-  for (; ; /* continue until no more item */ offset += maxItemsPerRequest) {
+  let itemsRemainingToBeFetched = true;
+
+  while (itemsRemainingToBeFetched) {
     const getTxsURL = getTxsURLTemplate.replace("{offset}", String(offset));
 
     const txs = await helpers.getJSON<TODO_TypeThis>(
@@ -91,10 +93,13 @@ async function getPayloads(
     // when the limit includes the total number of transactions,
     // no need to go further
     if (payload.length === 0) {
+      itemsRemainingToBeFetched = false;
       break;
     }
 
     payloads.push(payload);
+
+    offset += maxItemsPerRequest;
   }
 
   return payloads;

--- a/src/comparison/compareOperations.ts
+++ b/src/comparison/compareOperations.ts
@@ -200,6 +200,10 @@ const showOperations = (
     actual = chalk.blueBright(actual.concat(" [failed]"));
   }
 
+  if (A.operationType.includes("token") || B?.operationType.includes("token")) {
+    actual = chalk.white(actual.concat(" [token]"));
+  }
+
   switch (status) {
     case "Match":
       console.log(

--- a/src/comparison/compareOperations.ts
+++ b/src/comparison/compareOperations.ts
@@ -197,11 +197,11 @@ const showOperations = (
     A.operationType === "Failed to send" ||
     B?.operationType === "Failed to send"
   ) {
-    actual = chalk.blueBright(actual.concat(" [failed]"));
+    actual = chalk.blueBright(actual.concat("\t[failed]"));
   }
 
   if (A.operationType.includes("token") || B?.operationType.includes("token")) {
-    actual = chalk.white(actual.concat(" [token]"));
+    actual = chalk.white(actual.concat("\t[token]"));
   }
 
   switch (status) {

--- a/src/display.ts
+++ b/src/display.ts
@@ -191,6 +191,11 @@ function showSortedOperations(sortedOperations: Operation[]) {
         // case 4. Sent to external address
         status = status.concat(" →");
       }
+
+      if (operationType.includes("token")) {
+        // Token (Ethereum)
+        status = status.concat(" t");
+      }
     }
 
     console.log(status);

--- a/src/models/operation.ts
+++ b/src/models/operation.ts
@@ -5,6 +5,7 @@ type OperationType =
   | "Received (non-sibling to change)" // Received - edge case: address not belonging to the xpub
   //                                                            sending funds to change address
   | "Sent" // Sent - common case
+  | "Sent (token)" // Sent - token
   | "Sent to self" // Sent - edge case 1: The recipient is the sender (identity)
   | "Sent to sibling" // Sent - edge case 2: recipient belongs to same xpub ("sibling")
   | "Failed to send"; // Sent - edge case 3: failed send operation that impacts the balance (fees) (Ethereum)

--- a/src/templates/report.html.ts
+++ b/src/templates/report.html.ts
@@ -109,6 +109,10 @@ export const reportTemplate = `
         color: #4e2cb1 !important;
       }
 
+      .token_operation {
+        color: #214c9c !important;
+      }
+
       .comparison_mismatch {
         color: #cc0000 !important;
       }


### PR DESCRIPTION
Support Ethereum tokens (e.g., ERC20) operations.

This update makes these operations properly identified, and no longer erroneously labelled as `Extra operation`s.

From the terminal, they are identified with a `t` (operations history) and a `[token]` comparison.

![CLI](https://user-images.githubusercontent.com/66550865/134012267-19ddf370-45e0-4357-8388-16be57a52eb5.png)

In the HTML report, they are represented in blue, as `Sent (token)` operations.

![HTML](https://user-images.githubusercontent.com/66550865/134012288-fee2490e-46f9-4642-8d7d-53f59826a83c.png)

In the JSON report, they are identified as `Sent (token)` operations.

**Note that the current implementation does not check the token name, symbol, or amount, just that the transaction occurred.**
