### PR TITLE
feat(balance only): remove transactions field/table from reports

### DIFF
--- a/src/actions/checkBalance.ts
+++ b/src/actions/checkBalance.ts
@@ -128,7 +128,7 @@ async function scanAddresses(
 
   // process transactions
   display.transientLine(chalk.yellowBright("Processing transactions..."));
-  if (!balanceOnly){
+  if (!balanceOnly) {
     addresses.forEach((address) => {
       getTransactions(address, ownAddresses);
     });
@@ -154,7 +154,7 @@ async function addressAnalysis(addressToScan: string, balanceOnly: boolean) {
 
   await getStats(address);
 
-  if (!balanceOnly){
+  if (!balanceOnly) {
     getTransactions(address);
   }
 
@@ -168,7 +168,11 @@ async function addressAnalysis(addressToScan: string, balanceOnly: boolean) {
   };
 }
 
-async function run(itemToScan: string, balanceOnly: boolean, scanLimits?: ScanLimits) {
+async function run(
+  itemToScan: string,
+  balanceOnly: boolean,
+  scanLimits?: ScanLimits,
+) {
   if (configuration.currency.utxo_based) {
     return xpubAnalysis(itemToScan, balanceOnly, scanLimits);
   } else {
@@ -176,7 +180,11 @@ async function run(itemToScan: string, balanceOnly: boolean, scanLimits?: ScanLi
   }
 }
 
-async function xpubAnalysis(xpub: string, balanceOnly: boolean, scanLimits?: ScanLimits) {
+async function xpubAnalysis(
+  xpub: string,
+  balanceOnly: boolean,
+  scanLimits?: ScanLimits,
+) {
   let activeAddresses: Address[] = [];
   const summary: TODO_TypeThis[] = [];
 
@@ -197,7 +205,12 @@ async function xpubAnalysis(xpub: string, balanceOnly: boolean, scanLimits?: Sca
   }
 
   for (const derivationMode of derivationModes!) {
-    const results = await scanAddresses(derivationMode, xpub, balanceOnly, scanLimits);
+    const results = await scanAddresses(
+      derivationMode,
+      xpub,
+      balanceOnly,
+      scanLimits,
+    );
 
     activeAddresses = activeAddresses.concat(results.addresses);
 

--- a/src/actions/scanner.ts
+++ b/src/actions/scanner.ts
@@ -81,7 +81,12 @@ export class Scanner {
       const summary = scanResult.summary;
       const actualTransactions = getSortedOperations(actualAddresses);
 
-      display.showResults(actualUTXOs, actualTransactions, summary, this.balanceOnly);
+      display.showResults(
+        actualUTXOs,
+        actualTransactions,
+        summary,
+        this.balanceOnly,
+      );
 
       const partialScan = typeof this.scanLimits !== "undefined";
 
@@ -117,6 +122,11 @@ export class Scanner {
         // Augmented import mode:
         // Use of an augmented JSON to compare smart contract interactions
         mode += " | Augmented Import";
+      }
+
+      if (this.balanceOnly) {
+        // Balance only mode
+        mode += " | Balance Only";
       }
 
       const meta: ScanMeta = {

--- a/src/display.ts
+++ b/src/display.ts
@@ -287,7 +287,7 @@ function showResults(
   }
 
   showSortedUTXOs(sortedUTXOs);
-  if (!balanceOnly){
+  if (!balanceOnly) {
     showSortedOperations(sortedOperations);
   }
 

--- a/src/input/args.ts
+++ b/src/input/args.ts
@@ -94,12 +94,15 @@ export const getArgs = (): TODO_TypeThis => {
         "Import balance for comparison (has to be in base unit) for comparison",
       demand: false,
       type: "string",
-    }).option("balance-only", {
-      description: "Do not fetch operations, only balance of the account (utxo-list for btc)",
+    })
+    .option("balance-only", {
+      description:
+        "Do not fetch operations, only balance of the account (utxo-list for btc)",
       demand: false,
       type: "boolean",
       default: false,
-    }).option("utxos", {
+    })
+    .option("utxos", {
       description: "Import UTXOs (file) for comparison",
       demand: false,
       type: "string",

--- a/src/input/check.ts
+++ b/src/input/check.ts
@@ -47,9 +47,10 @@ export const checkArgs = (args: TODO_TypeThis, argv: string[]): void => {
     }
   }
 
-  if (args.balanceOnly && (args.operations || args.import)){
+  if (args.balanceOnly && (args.operations || args.import)) {
     throw new Error("You cannot pass an operation file in --balance-only mode");
   }
+
   // currency: exists
   if (typeof currency !== "undefined") {
     args.currency = args.currency.toUpperCase();

--- a/src/templates/report.html.ts
+++ b/src/templates/report.html.ts
@@ -385,33 +385,13 @@ export const reportTemplate = `
     </div>
     </li>
 
-    {utxos}
+    {utxos_table}
 
-    <li class="tab">
-    <input type="radio" name="tabs" id="tab4" />
-    <label for="tab4">Transactions</label>
-    <div id="tab-content4" class="content">
-    <div class="warning">{warning}</div>
-      <table>
-        <thead>
-          <tr>
-            <th>Date</th>
-            <th>Block</th>
-            <th>Tx id</th>
-            <th>Address</th>
-            <th>Amount</th>
-            <th>Type</th>
-          </tr>
-        </thead>
-        <tbody>
-          {transactions}
-        </tbody>
-      </table>
-    </div>
-    </li>
+    {transactions_table}
 
-    {comparisons}
-    {diff}
+    {comparisons_table}
+
+    {diff_table}
     </ul>
 
   </body>


### PR DESCRIPTION
In `balance only` mode:
- all reports: specify `Balance Only` in metadata
- HTML report: do not display the transactions table but display the UTXOs (when applicable)
- JSON report: remove `transactions` and `diffs` fields

<img width="1277" alt="report" src="https://user-images.githubusercontent.com/66550865/138445907-a49652da-e0cb-4b68-b806-a6930b852c8f.png">

