### PR TITLE
Ask Users to Use Node LTS (OpenSSL Issue)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17-alpine
+FROM node:lts-alpine
 
 ENV PYTHONUNBUFFERED=1
 ENV TERM xterm-256color

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Given an extended public key (xpub, Ltub, _etc._), get the balances of its deriv
 
 ## Prerequisites
 
-- Node.js
+- Node.js **LTS** (note: using Node v17 may trigger [this OpenSSL-related error](https://github.com/webpack/webpack/issues/14532))
 - Docker (if you want to use the docker image)
 
 ## Install

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -12,11 +12,11 @@
         "@types/bchaddrjs": "0.4.0",
         "@types/bitcore-lib-cash": "8.23.5",
         "@types/html-minifier": "4.0.2",
-        "@types/node": "17.0.24",
+        "@types/node": "17.0.25",
         "@types/object-hash": "2.2.1",
         "@types/yargs": "17.0.10",
-        "@typescript-eslint/eslint-plugin": "5.19.0",
-        "@typescript-eslint/parser": "5.19.0",
+        "@typescript-eslint/eslint-plugin": "5.20.0",
+        "@typescript-eslint/parser": "5.20.0",
         "axios": "0.26.1",
         "bchaddrjs": "0.5.2",
         "bignumber.js": "9.0.2",
@@ -2398,9 +2398,9 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
     },
     "node_modules/@types/node": {
-      "version": "17.0.24",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.24.tgz",
-      "integrity": "sha512-aveCYRQbgTH9Pssp1voEP7HiuWlD2jW2BO56w+bVrJn04i61yh6mRfoKO6hEYQD9vF+W8Chkwc6j1M36uPkx4g=="
+      "version": "17.0.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.25.tgz",
+      "integrity": "sha512-wANk6fBrUwdpY4isjWrKTufkrXdu1D2YHCot2fD/DfWxF5sMrVSA+KN7ydckvaTCh0HiqX9IVl0L5/ZoXg5M7w=="
     },
     "node_modules/@types/object-hash": {
       "version": "2.2.1",
@@ -2466,13 +2466,13 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.19.0.tgz",
-      "integrity": "sha512-w59GpFqDYGnWFim9p6TGJz7a3qWeENJuAKCqjGSx+Hq/bwq3RZwXYqy98KIfN85yDqz9mq6QXiY5h0FjGQLyEg==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.20.0.tgz",
+      "integrity": "sha512-fapGzoxilCn3sBtC6NtXZX6+P/Hef7VDbyfGqTTpzYydwhlkevB+0vE0EnmHPVTVSy68GUncyJ/2PcrFBeCo5Q==",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.19.0",
-        "@typescript-eslint/type-utils": "5.19.0",
-        "@typescript-eslint/utils": "5.19.0",
+        "@typescript-eslint/scope-manager": "5.20.0",
+        "@typescript-eslint/type-utils": "5.20.0",
+        "@typescript-eslint/utils": "5.20.0",
         "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
@@ -2513,13 +2513,13 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.19.0.tgz",
-      "integrity": "sha512-yhktJjMCJX8BSBczh1F/uY8wGRYrBeyn84kH6oyqdIJwTGKmzX5Qiq49LRQ0Jh0LXnWijEziSo6BRqny8nqLVQ==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.20.0.tgz",
+      "integrity": "sha512-UWKibrCZQCYvobmu3/N8TWbEeo/EPQbS41Ux1F9XqPzGuV7pfg6n50ZrFo6hryynD8qOTTfLHtHjjdQtxJ0h/w==",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.19.0",
-        "@typescript-eslint/types": "5.19.0",
-        "@typescript-eslint/typescript-estree": "5.19.0",
+        "@typescript-eslint/scope-manager": "5.20.0",
+        "@typescript-eslint/types": "5.20.0",
+        "@typescript-eslint/typescript-estree": "5.20.0",
         "debug": "^4.3.2"
       },
       "engines": {
@@ -2539,12 +2539,12 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.19.0.tgz",
-      "integrity": "sha512-Fz+VrjLmwq5fbQn5W7cIJZ066HxLMKvDEmf4eu1tZ8O956aoX45jAuBB76miAECMTODyUxH61AQM7q4/GOMQ5g==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.20.0.tgz",
+      "integrity": "sha512-h9KtuPZ4D/JuX7rpp1iKg3zOH0WNEa+ZIXwpW/KWmEFDxlA/HSfCMhiyF1HS/drTICjIbpA6OqkAhrP/zkCStg==",
       "dependencies": {
-        "@typescript-eslint/types": "5.19.0",
-        "@typescript-eslint/visitor-keys": "5.19.0"
+        "@typescript-eslint/types": "5.20.0",
+        "@typescript-eslint/visitor-keys": "5.20.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2555,11 +2555,11 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.19.0.tgz",
-      "integrity": "sha512-O6XQ4RI4rQcBGshTQAYBUIGsKqrKeuIOz9v8bckXZnSeXjn/1+BDZndHLe10UplQeJLXDNbaZYrAytKNQO2T4Q==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.20.0.tgz",
+      "integrity": "sha512-WxNrCwYB3N/m8ceyoGCgbLmuZwupvzN0rE8NBuwnl7APgjv24ZJIjkNzoFBXPRCGzLNkoU/WfanW0exvp/+3Iw==",
       "dependencies": {
-        "@typescript-eslint/utils": "5.19.0",
+        "@typescript-eslint/utils": "5.20.0",
         "debug": "^4.3.2",
         "tsutils": "^3.21.0"
       },
@@ -2580,9 +2580,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.19.0.tgz",
-      "integrity": "sha512-zR1ithF4Iyq1wLwkDcT+qFnhs8L5VUtjgac212ftiOP/ZZUOCuuF2DeGiZZGQXGoHA50OreZqLH5NjDcDqn34w==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.20.0.tgz",
+      "integrity": "sha512-+d8wprF9GyvPwtoB4CxBAR/s0rpP25XKgnOvMf/gMXYDvlUC3rPFHupdTQ/ow9vn7UDe5rX02ovGYQbv/IUCbg==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -2592,12 +2592,12 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.19.0.tgz",
-      "integrity": "sha512-dRPuD4ocXdaE1BM/dNR21elSEUPKaWgowCA0bqJ6YbYkvtrPVEvZ+zqcX5a8ECYn3q5iBSSUcBBD42ubaOp0Hw==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.20.0.tgz",
+      "integrity": "sha512-36xLjP/+bXusLMrT9fMMYy1KJAGgHhlER2TqpUVDYUQg4w0q/NW/sg4UGAgVwAqb8V4zYg43KMUpM8vV2lve6w==",
       "dependencies": {
-        "@typescript-eslint/types": "5.19.0",
-        "@typescript-eslint/visitor-keys": "5.19.0",
+        "@typescript-eslint/types": "5.20.0",
+        "@typescript-eslint/visitor-keys": "5.20.0",
         "debug": "^4.3.2",
         "globby": "^11.0.4",
         "is-glob": "^4.0.3",
@@ -2617,37 +2617,29 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/lru-cache": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.1.tgz",
-      "integrity": "sha512-E1v547OCgJvbvevfjgK9sNKIVXO96NnsTsFPBlg4ZxjhsJSODoH9lk8Bm0OxvHNm6Vm5Yqkl/1fErDxhYL8Skg==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.3.6",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
-      "integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
       "dependencies": {
-        "lru-cache": "^7.4.0"
+        "lru-cache": "^6.0.0"
       },
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
-        "node": "^10.0.0 || ^12.0.0 || ^14.0.0 || >=16.0.0"
+        "node": ">=10"
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.19.0.tgz",
-      "integrity": "sha512-ZuEckdupXpXamKvFz/Ql8YnePh2ZWcwz7APICzJL985Rp5C2AYcHO62oJzIqNhAMtMK6XvrlBTZeNG8n7gS3lQ==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.20.0.tgz",
+      "integrity": "sha512-lHONGJL1LIO12Ujyx8L8xKbwWSkoUKFSO+0wDAqGXiudWB2EO7WEUT+YZLtVbmOmSllAjLb9tpoIPwpRe5Tn6w==",
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.19.0",
-        "@typescript-eslint/types": "5.19.0",
-        "@typescript-eslint/typescript-estree": "5.19.0",
+        "@typescript-eslint/scope-manager": "5.20.0",
+        "@typescript-eslint/types": "5.20.0",
+        "@typescript-eslint/typescript-estree": "5.20.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -2683,11 +2675,11 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.19.0.tgz",
-      "integrity": "sha512-Ym7zZoMDZcAKWsULi2s7UMLREdVQdScPQ/fKWMYefarCztWlHPFVJo8racf8R0Gc8FAEJ2eD4of8As1oFtnQlQ==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.20.0.tgz",
+      "integrity": "sha512-1flRpNF+0CAQkMNlTJ6L/Z5jiODG/e5+7mk6XwtPOUS3UrTz3UOiAg9jG2VtKsWI6rZQfy4C6a232QNRZTRGlg==",
       "dependencies": {
-        "@typescript-eslint/types": "5.19.0",
+        "@typescript-eslint/types": "5.20.0",
         "eslint-visitor-keys": "^3.0.0"
       },
       "engines": {
@@ -9287,9 +9279,9 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
     },
     "@types/node": {
-      "version": "17.0.24",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.24.tgz",
-      "integrity": "sha512-aveCYRQbgTH9Pssp1voEP7HiuWlD2jW2BO56w+bVrJn04i61yh6mRfoKO6hEYQD9vF+W8Chkwc6j1M36uPkx4g=="
+      "version": "17.0.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.25.tgz",
+      "integrity": "sha512-wANk6fBrUwdpY4isjWrKTufkrXdu1D2YHCot2fD/DfWxF5sMrVSA+KN7ydckvaTCh0HiqX9IVl0L5/ZoXg5M7w=="
     },
     "@types/object-hash": {
       "version": "2.2.1",
@@ -9349,13 +9341,13 @@
       "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw=="
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.19.0.tgz",
-      "integrity": "sha512-w59GpFqDYGnWFim9p6TGJz7a3qWeENJuAKCqjGSx+Hq/bwq3RZwXYqy98KIfN85yDqz9mq6QXiY5h0FjGQLyEg==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.20.0.tgz",
+      "integrity": "sha512-fapGzoxilCn3sBtC6NtXZX6+P/Hef7VDbyfGqTTpzYydwhlkevB+0vE0EnmHPVTVSy68GUncyJ/2PcrFBeCo5Q==",
       "requires": {
-        "@typescript-eslint/scope-manager": "5.19.0",
-        "@typescript-eslint/type-utils": "5.19.0",
-        "@typescript-eslint/utils": "5.19.0",
+        "@typescript-eslint/scope-manager": "5.20.0",
+        "@typescript-eslint/type-utils": "5.20.0",
+        "@typescript-eslint/utils": "5.20.0",
         "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
@@ -9375,47 +9367,47 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.19.0.tgz",
-      "integrity": "sha512-yhktJjMCJX8BSBczh1F/uY8wGRYrBeyn84kH6oyqdIJwTGKmzX5Qiq49LRQ0Jh0LXnWijEziSo6BRqny8nqLVQ==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.20.0.tgz",
+      "integrity": "sha512-UWKibrCZQCYvobmu3/N8TWbEeo/EPQbS41Ux1F9XqPzGuV7pfg6n50ZrFo6hryynD8qOTTfLHtHjjdQtxJ0h/w==",
       "requires": {
-        "@typescript-eslint/scope-manager": "5.19.0",
-        "@typescript-eslint/types": "5.19.0",
-        "@typescript-eslint/typescript-estree": "5.19.0",
+        "@typescript-eslint/scope-manager": "5.20.0",
+        "@typescript-eslint/types": "5.20.0",
+        "@typescript-eslint/typescript-estree": "5.20.0",
         "debug": "^4.3.2"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.19.0.tgz",
-      "integrity": "sha512-Fz+VrjLmwq5fbQn5W7cIJZ066HxLMKvDEmf4eu1tZ8O956aoX45jAuBB76miAECMTODyUxH61AQM7q4/GOMQ5g==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.20.0.tgz",
+      "integrity": "sha512-h9KtuPZ4D/JuX7rpp1iKg3zOH0WNEa+ZIXwpW/KWmEFDxlA/HSfCMhiyF1HS/drTICjIbpA6OqkAhrP/zkCStg==",
       "requires": {
-        "@typescript-eslint/types": "5.19.0",
-        "@typescript-eslint/visitor-keys": "5.19.0"
+        "@typescript-eslint/types": "5.20.0",
+        "@typescript-eslint/visitor-keys": "5.20.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.19.0.tgz",
-      "integrity": "sha512-O6XQ4RI4rQcBGshTQAYBUIGsKqrKeuIOz9v8bckXZnSeXjn/1+BDZndHLe10UplQeJLXDNbaZYrAytKNQO2T4Q==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.20.0.tgz",
+      "integrity": "sha512-WxNrCwYB3N/m8ceyoGCgbLmuZwupvzN0rE8NBuwnl7APgjv24ZJIjkNzoFBXPRCGzLNkoU/WfanW0exvp/+3Iw==",
       "requires": {
-        "@typescript-eslint/utils": "5.19.0",
+        "@typescript-eslint/utils": "5.20.0",
         "debug": "^4.3.2",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.19.0.tgz",
-      "integrity": "sha512-zR1ithF4Iyq1wLwkDcT+qFnhs8L5VUtjgac212ftiOP/ZZUOCuuF2DeGiZZGQXGoHA50OreZqLH5NjDcDqn34w=="
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.20.0.tgz",
+      "integrity": "sha512-+d8wprF9GyvPwtoB4CxBAR/s0rpP25XKgnOvMf/gMXYDvlUC3rPFHupdTQ/ow9vn7UDe5rX02ovGYQbv/IUCbg=="
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.19.0.tgz",
-      "integrity": "sha512-dRPuD4ocXdaE1BM/dNR21elSEUPKaWgowCA0bqJ6YbYkvtrPVEvZ+zqcX5a8ECYn3q5iBSSUcBBD42ubaOp0Hw==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.20.0.tgz",
+      "integrity": "sha512-36xLjP/+bXusLMrT9fMMYy1KJAGgHhlER2TqpUVDYUQg4w0q/NW/sg4UGAgVwAqb8V4zYg43KMUpM8vV2lve6w==",
       "requires": {
-        "@typescript-eslint/types": "5.19.0",
-        "@typescript-eslint/visitor-keys": "5.19.0",
+        "@typescript-eslint/types": "5.20.0",
+        "@typescript-eslint/visitor-keys": "5.20.0",
         "debug": "^4.3.2",
         "globby": "^11.0.4",
         "is-glob": "^4.0.3",
@@ -9423,30 +9415,25 @@
         "tsutils": "^3.21.0"
       },
       "dependencies": {
-        "lru-cache": {
-          "version": "7.8.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.1.tgz",
-          "integrity": "sha512-E1v547OCgJvbvevfjgK9sNKIVXO96NnsTsFPBlg4ZxjhsJSODoH9lk8Bm0OxvHNm6Vm5Yqkl/1fErDxhYL8Skg=="
-        },
         "semver": {
-          "version": "7.3.6",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
-          "integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
           "requires": {
-            "lru-cache": "^7.4.0"
+            "lru-cache": "^6.0.0"
           }
         }
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.19.0.tgz",
-      "integrity": "sha512-ZuEckdupXpXamKvFz/Ql8YnePh2ZWcwz7APICzJL985Rp5C2AYcHO62oJzIqNhAMtMK6XvrlBTZeNG8n7gS3lQ==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.20.0.tgz",
+      "integrity": "sha512-lHONGJL1LIO12Ujyx8L8xKbwWSkoUKFSO+0wDAqGXiudWB2EO7WEUT+YZLtVbmOmSllAjLb9tpoIPwpRe5Tn6w==",
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.19.0",
-        "@typescript-eslint/types": "5.19.0",
-        "@typescript-eslint/typescript-estree": "5.19.0",
+        "@typescript-eslint/scope-manager": "5.20.0",
+        "@typescript-eslint/types": "5.20.0",
+        "@typescript-eslint/typescript-estree": "5.20.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -9468,11 +9455,11 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.19.0.tgz",
-      "integrity": "sha512-Ym7zZoMDZcAKWsULi2s7UMLREdVQdScPQ/fKWMYefarCztWlHPFVJo8racf8R0Gc8FAEJ2eD4of8As1oFtnQlQ==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.20.0.tgz",
+      "integrity": "sha512-1flRpNF+0CAQkMNlTJ6L/Z5jiODG/e5+7mk6XwtPOUS3UrTz3UOiAg9jG2VtKsWI6rZQfy4C6a232QNRZTRGlg==",
       "requires": {
-        "@typescript-eslint/types": "5.19.0",
+        "@typescript-eslint/types": "5.20.0",
         "eslint-visitor-keys": "^3.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "xpub-scan": "./lib/scan.js"
   },
   "scripts": {
+    "scan": "node ./lib/scan.js",
     "clean": "yarn cache clean --force && rm -rf lib/",
     "build": "tsc && chmod +x ./lib/scan.js",
     "test": "jest",
@@ -34,11 +35,11 @@
     "@types/bchaddrjs": "0.4.0",
     "@types/bitcore-lib-cash": "8.23.5",
     "@types/html-minifier": "4.0.2",
-    "@types/node": "17.0.24",
+    "@types/node": "17.0.25",
     "@types/object-hash": "2.2.1",
     "@types/yargs": "17.0.10",
-    "@typescript-eslint/eslint-plugin": "5.19.0",
-    "@typescript-eslint/parser": "5.19.0",
+    "@typescript-eslint/eslint-plugin": "5.20.0",
+    "@typescript-eslint/parser": "5.20.0",
     "axios": "0.26.1",
     "bchaddrjs": "0.5.2",
     "bignumber.js": "9.0.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "xpub-scan": "./lib/scan.js"
   },
   "scripts": {
-    "scan": "node ./lib/scan.js",
     "clean": "yarn cache clean --force && rm -rf lib/",
     "build": "tsc && chmod +x ./lib/scan.js",
     "test": "jest",


### PR DESCRIPTION
Using Node v17+ may trigger the following error, related to OpenSSL:

```
error:0308010C:digital envelope routines::unsupported
```

OpenSSL is being used by the `bitcoinjs-lib`. Therefore, such an error is likely to occur when Bitcoin addresses are being derived from the xpub.

In order to avoid this issue, users will be asked to use Node LTS. Furthermore, the Docker image will use Node LTS-Alpine instead of Node 17-Alpine.

More context: https://github.com/webpack/webpack/issues/14532