### PR TITLE
fix: change Dockerfile base to explicit 16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine
+FROM node:16-alpine
 
 ENV PYTHONUNBUFFERED=1
 ENV TERM xterm-256color


### PR DESCRIPTION
The docker build was failing.

I noticed the README says it might break under node 17. 

Changing the base image to refer explicitly to node 16 appears to fix it so that it can at build.